### PR TITLE
add acceptable_attributes concern.

### DIFF
--- a/lib/tinybucket/model/branch_restriction.rb
+++ b/lib/tinybucket/model/branch_restriction.rb
@@ -3,7 +3,7 @@ module Tinybucket
     class BranchRestriction < Base
       include Tinybucket::Model::Concerns::RepositoryKeys
 
-      attr_accessor :groups, :id, :kind, :links, :pattern, :users, :uuid
+      acceptable_attributes :groups, :id, :kind, :links, :pattern, :users, :uuid
 
       def update(_params)
         fail NotImplementedError

--- a/lib/tinybucket/model/comment.rb
+++ b/lib/tinybucket/model/comment.rb
@@ -4,7 +4,7 @@ module Tinybucket
       include Tinybucket::Model::Concerns::RepositoryKeys
       include Tinybucket::Model::Concerns::Reloadable
 
-      attr_accessor \
+      acceptable_attributes \
         :links, :id, :parent,  :filename, :content, :user, :inline, \
         :created_on, :updated_on, :uuid
 

--- a/lib/tinybucket/model/commit.rb
+++ b/lib/tinybucket/model/commit.rb
@@ -4,7 +4,7 @@ module Tinybucket
       include Tinybucket::Model::Concerns::RepositoryKeys
       include Tinybucket::Model::Concerns::Reloadable
 
-      attr_accessor \
+      acceptable_attributes \
         :hash, :links, :repository, :author, :parents, :date,
         :message, :participants, :uuid
 

--- a/lib/tinybucket/model/concerns.rb
+++ b/lib/tinybucket/model/concerns.rb
@@ -4,6 +4,7 @@ module Tinybucket
       extend ActiveSupport::Autoload
 
       [
+        :AcceptableAttributes,
         :RepositoryKeys,
         :Reloadable
       ].each do |mod_name|

--- a/lib/tinybucket/model/concerns/acceptable_attributes.rb
+++ b/lib/tinybucket/model/concerns/acceptable_attributes.rb
@@ -1,0 +1,32 @@
+module Tinybucket
+  module Model
+    module Concerns
+      module AcceptableAttributes
+        extend ActiveSupport::Concern
+
+        included do
+          def self.acceptable_attributes(*attrs)
+            @_acceptable_attributes = attrs.map(&:intern)
+
+            attr_accessor(*attrs)
+          end
+
+          def self.acceptable_attribute?(key)
+            return false if @_acceptable_attributes.nil?
+            @_acceptable_attributes.include?(key.intern)
+          end
+
+          protected
+
+          def acceptable_attribute?(key)
+            self.class.acceptable_attribute?(key)
+          end
+
+          def acceptable_attributes
+            self.class.instance_variable_get(:@_acceptable_attributes) || []
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/model/error_response.rb
+++ b/lib/tinybucket/model/error_response.rb
@@ -1,7 +1,7 @@
 module Tinybucket
   module Model
     class ErrorResponse < Base
-      attr_accessor :message, :fields, :detail, :id, :uuid
+      acceptable_attributes :message, :fields, :detail, :id, :uuid
     end
   end
 end

--- a/lib/tinybucket/model/profile.rb
+++ b/lib/tinybucket/model/profile.rb
@@ -3,7 +3,7 @@ module Tinybucket
     class Profile < Base
       include Tinybucket::Model::Concerns::Reloadable
 
-      attr_accessor \
+      acceptable_attributes \
         :username, :kind, :website, :display_name,
         :links, :created_on, :location, :type, :uuid
 

--- a/lib/tinybucket/model/pull_request.rb
+++ b/lib/tinybucket/model/pull_request.rb
@@ -4,7 +4,7 @@ module Tinybucket
       include Tinybucket::Model::Concerns::RepositoryKeys
       include Tinybucket::Model::Concerns::Reloadable
 
-      attr_accessor \
+      acceptable_attributes \
         :state, :description, :links, :title, :close_source_branch,
         :destination, :reason, :id, :source, :created_on, :author, :updated_on,
         :merge_commit, :closed_by, :reviewers, :participants, :uuid

--- a/lib/tinybucket/model/repository.rb
+++ b/lib/tinybucket/model/repository.rb
@@ -4,9 +4,10 @@ module Tinybucket
       include Tinybucket::Model::Concerns::RepositoryKeys
       include Tinybucket::Model::Concerns::Reloadable
 
-      attr_accessor :scm, :has_wiki, :description, :links, :updated_on,
-                    :fork_policy, :created_on, :owner, :size, :parent, :uuid,
-                    :has_issues, :is_private, :full_name, :name, :language
+      acceptable_attributes \
+        :scm, :has_wiki, :description, :links, :updated_on,
+        :fork_policy, :created_on, :owner, :size, :parent, :uuid,
+        :has_issues, :is_private, :full_name, :name, :language
 
       def create(_params)
         fail NotImplementedError

--- a/lib/tinybucket/model/team.rb
+++ b/lib/tinybucket/model/team.rb
@@ -3,7 +3,7 @@ module Tinybucket
     class Team < Base
       include Tinybucket::Model::Concerns::Reloadable
 
-      attr_accessor \
+      acceptable_attributes \
         :username, :kind, :website, :display_name, :uuid,
         :links, :created_on, :location, :type
 

--- a/spec/fixtures/branch_restriction.json
+++ b/spec/fixtures/branch_restriction.json
@@ -1,0 +1,17 @@
+{
+    "groups": [],
+    "id": 52,
+    "kind": "delete",
+    "links": [
+        {
+            "href": "https://api.bitbucket.org/2.0/repositories/manthony/restrictiontest/branch-restrictions/52",
+            "rel": "self"
+        },
+        {
+            "href": "https://api.bitbucket.org/2.0/repositories/manthony/restrictiontest/branch-restrictions",
+            "rel": "parent"
+        }
+    ],
+    "pattern": "foobar/*",
+    "users": []
+}

--- a/spec/fixtures/comment.json
+++ b/spec/fixtures/comment.json
@@ -1,0 +1,30 @@
+{
+  "links": {
+    "self": {
+      "href": "https://bitbucket.org/api/2.0/repositories/tutorials/tutorials.bitbucket.org/pullrequests/2821/comments/839163"
+    },
+    "html": {
+      "href": "https://bitbucket.org/tutorials/tutorials.bitbucket.org/pull-request/2821/_/diff#comment-839163"
+    }
+  },
+  "content": {
+    "raw": "this is my first comment",
+    "markup": "markdown",
+    "html": "<p>this is my first comment</p>"
+  },
+  "created_on": "2013-11-19T21:19:24.138375+00:00",
+  "user": {
+    "username": "tutorials",
+    "display_name": "first name last",
+    "links": {
+      "self": {
+        "href": "https://bitbucket.org/api/2.0/users/tutorials"
+      },
+      "avatar": {
+        "href": "https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2013/Jul/17/tutorials-avatar-1826704565-4_avatar.png"
+      }
+    }
+  },
+  "updated_on": "2013-11-19T21:19:24.141013+00:00",
+  "id": 839163
+}

--- a/spec/fixtures/team.json
+++ b/spec/fixtures/team.json
@@ -1,0 +1,32 @@
+{
+    "username": "teamsinspace",
+    "website": null,
+    "display_name": "Teams In Space",
+    "uuid": "{61fc5cf6-d054-47d2-b4a9-061ccf858379}",
+    "links": {
+        "self": {
+            "href": "https://bitbucket.org/api/2.0/teams/teamsinspace"
+        },
+        "repositories": {
+            "href": "https://bitbucket.org/api/2.0/repositories/teamsinspace"
+        },
+        "html": {
+            "href": "https://bitbucket.org/teamsinspace"
+        },
+        "followers": {
+            "href": "https://bitbucket.org/api/2.0/teams/teamsinspace/followers"
+        },
+        "avatar": {
+            "href": "https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2014/Sep/24/teamsinspace-avatar-3731530358-7_avatar.png"
+        },
+        "members": {
+            "href": "https://bitbucket.org/api/2.0/teams/teamsinspace/members"
+        },
+        "following": {
+            "href": "https://bitbucket.org/api/2.0/teams/teamsinspace/following"
+        }
+    },
+    "created_on": "2014-04-08T00:00:14.070969+00:00",
+    "location": null,
+    "type": "team"
+}

--- a/spec/lib/tinybucket/model/branch_restriction_spec.rb
+++ b/spec/lib/tinybucket/model/branch_restriction_spec.rb
@@ -3,11 +3,13 @@ require 'spec_helper'
 RSpec.describe Tinybucket::Model::BranchRestriction do
   include ApiResponseMacros
 
+  let(:model_json) { load_json_fixture('branch_restriction') }
+
+  let(:request_method) { :get }
+  let(:request_path) { nil }
+
   let(:owner) { 'test_owner' }
   let(:slug)  { 'test_repo' }
-
-  # TODO: fix model_json
-  let(:model_json) { nil }
 
   let(:model) do
     m = Tinybucket::Model::BranchRestriction.new(model_json)
@@ -18,6 +20,10 @@ RSpec.describe Tinybucket::Model::BranchRestriction do
   end
 
   before { stub_apiresponse(:get, request_path, stub_options) if request_path }
+
+  it_behaves_like 'model has acceptable_attributes',
+                  Tinybucket::Model::BranchRestriction,
+                  load_json_fixture('branch_restriction')
 
   describe '#update' do
     pending 'TODO implement method'

--- a/spec/lib/tinybucket/model/comment_spec.rb
+++ b/spec/lib/tinybucket/model/comment_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Tinybucket::Model::Comment do
   include ApiResponseMacros
   include ModelMacros
 
+  let(:model_json) { load_json_fixture('comment') }
+
   let(:owner) { 'test_owner' }
   let(:slug)  { 'test_repo' }
 
@@ -14,6 +16,10 @@ RSpec.describe Tinybucket::Model::Comment do
     m.hash = '1'
     m
   end
+
+  it_behaves_like 'model has acceptable_attributes',
+                  Tinybucket::Model::Comment,
+                  load_json_fixture('comment')
 
   describe 'model can reloadable' do
     let(:comment) do

--- a/spec/lib/tinybucket/model/commit_spec.rb
+++ b/spec/lib/tinybucket/model/commit_spec.rb
@@ -4,12 +4,15 @@ RSpec.describe Tinybucket::Model::Commit do
   include ApiResponseMacros
   include ModelMacros
 
+  let(:model_json) { load_json_fixture('commit') }
+
+  let(:request_path) { nil }
+
   let(:owner) { 'test_owner' }
   let(:slug) { 'test_repo' }
 
   let(:model) do
-    json = JSON.load(File.read('spec/fixtures/commit.json'))
-    m = Tinybucket::Model::Commit.new(json)
+    m = Tinybucket::Model::Commit.new(model_json)
     m.repo_owner = owner
     m.repo_slug  = slug
     m.hash = '1'
@@ -17,9 +20,11 @@ RSpec.describe Tinybucket::Model::Commit do
     m
   end
 
-  let(:request_path) { nil }
-
   before { stub_apiresponse(:get, request_path) if request_path }
+
+  it_behaves_like 'model has acceptable_attributes',
+                  Tinybucket::Model::Commit,
+                  load_json_fixture('commit')
 
   describe 'model can reloadable' do
     let(:commit) do

--- a/spec/lib/tinybucket/model/profile_spec.rb
+++ b/spec/lib/tinybucket/model/profile_spec.rb
@@ -4,18 +4,23 @@ RSpec.describe Tinybucket::Model::Profile do
   include ApiResponseMacros
   include ModelMacros
 
+  let(:model_json) { load_json_fixture('profile') }
+
+  let(:request_path) { nil }
+
   let(:username) { 'test_owner' }
 
-  let(:model_json) { JSON.load(File.read('spec/fixtures/profile.json')) }
   let(:model) do
     m = Tinybucket::Model::Profile.new(model_json)
     m.username = username
     m
   end
 
-  let(:request_path) { nil }
-
   before { stub_apiresponse(:get, request_path) if request_path }
+
+  it_behaves_like 'model has acceptable_attributes',
+                  Tinybucket::Model::Profile,
+                  load_json_fixture('profile')
 
   describe 'model can reloadable' do
     let(:profile) do

--- a/spec/lib/tinybucket/model/pull_request_spec.rb
+++ b/spec/lib/tinybucket/model/pull_request_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Tinybucket::Model::PullRequest do
   include ApiResponseMacros
   include ModelMacros
 
-  let(:model_json) { JSON.load(File.read('spec/fixtures/pull_request.json')) }
+  let(:model_json) { load_json_fixture('pull_request') }
 
   let(:request_method) { :get }
   let(:request_path) { nil }
@@ -29,6 +29,10 @@ RSpec.describe Tinybucket::Model::PullRequest do
       stub_apiresponse(request_method, request_path, opts)
     end
   end
+
+  it_behaves_like 'model has acceptable_attributes',
+                  Tinybucket::Model::PullRequest,
+                  load_json_fixture('pull_request')
 
   describe 'model can reloadable' do
     let(:pr) do

--- a/spec/lib/tinybucket/model/repository_spec.rb
+++ b/spec/lib/tinybucket/model/repository_spec.rb
@@ -4,10 +4,14 @@ RSpec.describe Tinybucket::Model::Repository do
   include ApiResponseMacros
   include ModelMacros
 
+  let(:model_json) { load_json_fixture('repository') }
+
+  let(:request_path) { nil }
+  let(:stub_options) { {} }
+
   let(:owner) { 'test_owner' }
   let(:slug)  { 'test_repo' }
 
-  let(:model_json) { JSON.load(File.read('spec/fixtures/repository.json')) }
   let(:model) do
     m = Tinybucket::Model::Repository.new(model_json)
     m.repo_owner = owner
@@ -15,10 +19,12 @@ RSpec.describe Tinybucket::Model::Repository do
 
     m
   end
-  let(:request_path) { nil }
-  let(:stub_options) { {} }
 
   before { stub_apiresponse(:get, request_path, stub_options) if request_path }
+
+  it_behaves_like 'model has acceptable_attributes',
+                  Tinybucket::Model::Repository,
+                  load_json_fixture('repository')
 
   describe 'model can reloadable' do
     let(:repo) do

--- a/spec/lib/tinybucket/model/team_spec.rb
+++ b/spec/lib/tinybucket/model/team_spec.rb
@@ -4,18 +4,23 @@ RSpec.describe Tinybucket::Model::Team do
   include ApiResponseMacros
   include ModelMacros
 
+  let(:model_json) { load_json_fixture('team') }
+
+  let(:request_path) { nil }
+
   let(:teamname) { 'test_team' }
 
-  let(:model_json) { JSON.load(File.read('spec/fixtures/profile.json')) }
   let(:model) do
     m = Tinybucket::Model::Team.new(model_json)
     m.username = teamname
     m
   end
 
-  let(:request_path) { nil }
-
   before { stub_apiresponse(:get, request_path) if request_path }
+
+  it_behaves_like 'model has acceptable_attributes',
+                  Tinybucket::Model::Team,
+                  load_json_fixture('team')
 
   describe 'model can reloadable' do
     let(:team) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,5 +38,7 @@ logger.level = Logger::DEBUG
 Tinybucket.logger = logger
 
 RSpec.configure do |config|
+  config.extend FixtureMacros
+  config.include FixtureMacros
   config.order = 'random'
 end

--- a/spec/support/fixture_macros.rb
+++ b/spec/support/fixture_macros.rb
@@ -1,0 +1,5 @@
+module FixtureMacros
+  def load_json_fixture(suffix)
+    JSON.load(File.read('spec/fixtures/' + suffix + '.json'))
+  end
+end

--- a/spec/support/model_macros.rb
+++ b/spec/support/model_macros.rb
@@ -1,4 +1,30 @@
 module ModelMacros
+  RSpec.shared_examples 'model has acceptable_attributes' do |cls, model_json|
+    describe '#attribute=' do
+      subject { cls.new(json) }
+
+      context 'json contains only expected attrs' do
+        let(:json) { model_json }
+        it { expect { subject }.not_to raise_error }
+        it 'receive each attributes' do
+          json.each_pair do |key, value|
+            expect(subject.send(key.intern)).to eq(value)
+          end
+        end
+      end
+
+      context 'json contains un-acceptable attrs' do
+        let(:json) { model_json.merge('_un_acceptable_key' => 'some_value') }
+        it { expect { subject }.not_to raise_error }
+        it 'receive each acceptable attributes' do
+          model_json.each_pair do |key, value|
+            expect(subject.send(key.intern)).to eq(value)
+          end
+        end
+      end
+    end
+  end
+
   RSpec.shared_examples 'the model is reloadable' do
     describe '#load' do
       before do


### PR DESCRIPTION
Responses of Bitbucket REST APIs sometimes changed unexpectedly.

The cause of issue #46 is same with that.  

To avoid this problem, this pull request introduce `acceptable_attributes` to define acceptable attributes for each models.

With current tinybucket gem, all attributes of response from Bitbucket REST API should be defined setter method.([here](https://github.com/hirakiuc/tinybucket/compare/acceptable_attributes?expand=1#diff-e3f22b2c7841bddf3e5169f5b862ea84L19))

This pull request define `acceptable attribute` on each models to be enable to check whether each attribute should be set or not.

