### PR TITLE
share oauth_api_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,20 +48,17 @@ logger.level = Logger::WARN
 
 Tinybucket.configure do |config|
   config.logger = logger
+
+  # configure oauth_token/oauth_secret
+  config.oauth_token = 'key'
+  config.oauth_secret = 'secret'
 end
 ```
 
 ### init
 
 ```
-bucket = Tinybucket.new(oauth_token: 'key', oauth_secret: 'secret')
-```
-
-```
-bucket = Tinybucket.new do |config|
-  config.oauth_token  = 'key'
-  config.oauth_secret = 'secret'
-end
+bucket = Tinybucket.new
 ```
 
 #### teams Endpoint

--- a/lib/tinybucket.rb
+++ b/lib/tinybucket.rb
@@ -50,8 +50,8 @@ module Tinybucket
     include ActiveSupport::Configurable
     attr_accessor :logger, :api_client
 
-    def new(options = {}, &block)
-      @api_client = Tinybucket::Client.new(options, &block)
+    def new
+      @api_client = Tinybucket::Client.new
     end
 
     def configure

--- a/lib/tinybucket/api/base_api.rb
+++ b/lib/tinybucket/api/base_api.rb
@@ -4,27 +4,14 @@ module Tinybucket
       include Tinybucket::Connection
       include Tinybucket::Request
 
-      def initialize(config, options = {})
-        @config = filter_config(config)
+      def initialize(options = {})
         @options = options
-        yield if block_given?
       end
 
       protected
 
       def option(key)
         @options[key.intern]
-      end
-
-      def config(key)
-        @config[key.intern]
-      end
-
-      private
-
-      def filter_config(config)
-        keys = %i(oauth_token oauth_secret)
-        config.select { |key, _| keys.include?(key) }
       end
     end
   end

--- a/lib/tinybucket/api/branch_restrictions_api.rb
+++ b/lib/tinybucket/api/branch_restrictions_api.rb
@@ -11,15 +11,15 @@ module Tinybucket
                         Tinybucket::Parser::BranchRestrictionsParser)
 
         list.next_proc = next_proc(:list, options)
-        inject_api_config(list)
+        list
       end
 
       def find(restriction_id, options = {})
-        m = get_path(path_to_find(restriction_id),
-                     options,
-                     Tinybucket::Parser::BranchRestrictionParser)
-
-        inject_api_config(m)
+        get_path(
+          path_to_find(restriction_id),
+          options,
+          Tinybucket::Parser::BranchRestrictionParser
+        )
       end
     end
   end

--- a/lib/tinybucket/api/comments_api.rb
+++ b/lib/tinybucket/api/comments_api.rb
@@ -15,7 +15,7 @@ module Tinybucket
         list.next_proc = next_proc(:list, options)
 
         associate_with_target(list)
-        inject_api_config(list)
+        list
       end
 
       def find(comment_id, options = {})
@@ -24,7 +24,7 @@ module Tinybucket
                            Tinybucket::Parser::CommentParser)
 
         associate_with_target(comment)
-        inject_api_config(comment)
+        comment
       end
 
       private

--- a/lib/tinybucket/api/commits_api.rb
+++ b/lib/tinybucket/api/commits_api.rb
@@ -11,15 +11,15 @@ module Tinybucket
                         Tinybucket::Parser::CommitsParser)
 
         list.next_proc = next_proc(:list, options)
-        inject_api_config(list)
+        list
       end
 
       def find(revision, options = {})
-        m = get_path(path_to_find(revision),
-                     options,
-                     Tinybucket::Parser::CommitParser)
-
-        inject_api_config(m)
+        get_path(
+          path_to_find(revision),
+          options,
+          Tinybucket::Parser::CommitParser
+        )
       end
     end
   end

--- a/lib/tinybucket/api/helper/api_helper.rb
+++ b/lib/tinybucket/api/helper/api_helper.rb
@@ -10,17 +10,6 @@ module Tinybucket
           end
         end
 
-        def inject_api_config(result)
-          case result
-          when Tinybucket::Model::Page
-            result.items.map { |m| m.api_config = @config.dup }
-          when Tinybucket::Model::Base
-            result.api_config = @config.dup
-          end
-
-          result
-        end
-
         def urlencode(v, key)
           if v.blank? || (escaped = CGI.escape(v.to_s)).blank?
             msg = "Invalid #{key} parameter. (#{v})"

--- a/lib/tinybucket/api/pull_requests_api.rb
+++ b/lib/tinybucket/api/pull_requests_api.rb
@@ -11,15 +11,15 @@ module Tinybucket
                         Tinybucket::Parser::PullRequestsParser)
 
         list.next_proc = next_proc(:list, options)
-        inject_api_config(list)
+        list
       end
 
       def find(pr_id, options = {})
-        m = get_path(path_to_find(pr_id),
-                     options,
-                     Tinybucket::Parser::PullRequestParser)
-
-        inject_api_config(m)
+        get_path(
+          path_to_find(pr_id),
+          options,
+          Tinybucket::Parser::PullRequestParser
+        )
       end
 
       def commits(pr_id, options = {})
@@ -28,7 +28,7 @@ module Tinybucket
                         Tinybucket::Parser::CommitsParser)
 
         list.next_proc = next_proc(:commits, options)
-        inject_api_config(list)
+        list
       end
 
       def approve(pr_id, options = {})

--- a/lib/tinybucket/api/repo_api.rb
+++ b/lib/tinybucket/api/repo_api.rb
@@ -6,11 +6,11 @@ module Tinybucket
       attr_accessor :repo_owner, :repo_slug
 
       def find(options = {})
-        repo = get_path(path_to_find,
-                        options,
-                        Tinybucket::Parser::RepoParser)
-
-        inject_api_config(repo)
+        get_path(
+          path_to_find,
+          options,
+          Tinybucket::Parser::RepoParser
+        )
       end
 
       def watchers(options = {})
@@ -19,7 +19,7 @@ module Tinybucket
                         Tinybucket::Parser::ProfilesParser)
 
         list.next_proc = next_proc(:watchers, options)
-        inject_api_config(list)
+        list
       end
 
       def forks(options = {})
@@ -28,7 +28,7 @@ module Tinybucket
                         Tinybucket::Parser::ReposParser)
 
         list.next_proc = next_proc(:forks, options)
-        inject_api_config(list)
+        list
       end
     end
   end

--- a/lib/tinybucket/api/repos_api.rb
+++ b/lib/tinybucket/api/repos_api.rb
@@ -12,7 +12,7 @@ module Tinybucket
                         Tinybucket::Parser::ReposParser)
 
         list.next_proc = next_proc(:list, options)
-        inject_api_config(list)
+        list
       end
     end
   end

--- a/lib/tinybucket/api/team_api.rb
+++ b/lib/tinybucket/api/team_api.rb
@@ -4,11 +4,11 @@ module Tinybucket
       include Tinybucket::Api::Helper::TeamHelper
 
       def find(name, options = {})
-        m = get_path(path_to_find(name),
-                     options,
-                     Tinybucket::Parser::TeamParser)
-
-        inject_api_config(m)
+        get_path(
+          path_to_find(name),
+          options,
+          Tinybucket::Parser::TeamParser
+        )
       end
 
       def members(name, options = {})
@@ -17,7 +17,7 @@ module Tinybucket
                         Tinybucket::Parser::TeamsParser)
 
         list.next_proc = next_proc(:members, options)
-        inject_api_config(list)
+        list
       end
 
       def followers(name, options = {})
@@ -26,7 +26,7 @@ module Tinybucket
                         Tinybucket::Parser::TeamsParser)
 
         list.next_proc = next_proc(:followers, options)
-        inject_api_config(list)
+        list
       end
 
       def following(name, options = {})
@@ -35,7 +35,7 @@ module Tinybucket
                         Tinybucket::Parser::TeamsParser)
 
         list.next_proc = next_proc(:following, options)
-        inject_api_config(list)
+        list
       end
 
       def repos(name, options = {})
@@ -44,7 +44,7 @@ module Tinybucket
                         Tinybucket::Parser::ReposParser)
 
         list.next_proc = next_proc(:repos, options)
-        inject_api_config(list)
+        list
       end
     end
   end

--- a/lib/tinybucket/api/user_api.rb
+++ b/lib/tinybucket/api/user_api.rb
@@ -6,11 +6,11 @@ module Tinybucket
       attr_accessor :username
 
       def profile(options = {})
-        m = get_path(path_to_find,
-                     options,
-                     Tinybucket::Parser::ProfileParser)
-
-        inject_api_config(m)
+        get_path(
+          path_to_find,
+          options,
+          Tinybucket::Parser::ProfileParser
+        )
       end
 
       def followers(options = {})
@@ -19,7 +19,7 @@ module Tinybucket
                         Tinybucket::Parser::ProfilesParser)
 
         list.next_proc = next_proc(:followers, options)
-        inject_api_config(list)
+        list
       end
 
       def following(options = {})
@@ -28,7 +28,7 @@ module Tinybucket
                         Tinybucket::Parser::ProfilesParser)
 
         list.next_proc = next_proc(:following, options)
-        inject_api_config(list)
+        list
       end
 
       def repos(options = {})
@@ -37,7 +37,7 @@ module Tinybucket
                         Tinybucket::Parser::ReposParser)
 
         list.next_proc = next_proc(:repos, options)
-        inject_api_config(list)
+        list
       end
     end
   end

--- a/lib/tinybucket/api_factory.rb
+++ b/lib/tinybucket/api_factory.rb
@@ -1,7 +1,7 @@
 module Tinybucket
   class ApiFactory
     class << self
-      def create_instance(klass_name, config, options)
+      def create_instance(klass_name, options)
         options.symbolize_keys!
 
         klass =
@@ -14,7 +14,7 @@ module Tinybucket
             raise ArgumentError, 'must provide klass to be instantiated'
           end
 
-        klass.new config, options
+        klass.new options
       end
     end
   end

--- a/lib/tinybucket/client.rb
+++ b/lib/tinybucket/client.rb
@@ -1,15 +1,5 @@
 module Tinybucket
   class Client
-    include ActiveSupport::Configurable
-
-    def initialize(options = {})
-      options.each_pair do |key, value|
-        config.send("#{key}=", value)
-      end
-
-      yield(config) if block_given?
-    end
-
     # Get Repositories
     #
     # when you want to get repositories of the owner, call with owner, options.
@@ -50,21 +40,18 @@ module Tinybucket
       m = Tinybucket::Model::Repository.new({})
       m.repo_owner = owner
       m.repo_slug = repo_slug
-      m.api_config = config.dup
       m
     end
 
     def team(teamname)
       m = Tinybucket::Model::Team.new({})
       m.username = teamname
-      m.api_config = config.dup
       m
     end
 
     def user(username)
       m = Tinybucket::Model::Profile.new({})
       m.username = username
-      m.api_config = config.dup
       m
     end
 
@@ -89,7 +76,7 @@ module Tinybucket
     end
 
     def create_instance(name, options)
-      ApiFactory.create_instance(name, config, options)
+      ApiFactory.create_instance(name, options)
     end
   end
 end

--- a/lib/tinybucket/config.rb
+++ b/lib/tinybucket/config.rb
@@ -1,6 +1,6 @@
 module Tinybucket
   class Config
     include ActiveSupport::Configurable
-    config_accessor :logger
+    config_accessor :logger, :oauth_token, :oauth_secret
   end
 end

--- a/lib/tinybucket/connection.rb
+++ b/lib/tinybucket/connection.rb
@@ -32,8 +32,8 @@ module Tinybucket
     def default_middleware(_options)
       proc do |conn|
         oauth_secrets = {
-          consumer_key: config(:oauth_token),
-          consumer_secret: config(:oauth_secret)
+          consumer_key:    Tinybucket.config.oauth_token,
+          consumer_secret: Tinybucket.config.oauth_secret
         }
 
         conn.request :multipart

--- a/lib/tinybucket/model/base.rb
+++ b/lib/tinybucket/model/base.rb
@@ -3,7 +3,6 @@ module Tinybucket
     class Base
       include ::ActiveModel::Serializers::JSON
       include Concerns::AcceptableAttributes
-      attr_accessor :api_config
 
       def self.concern_included?(concern_name)
         mod_name = "Tinybucket::Model::Concerns::#{concern_name}".constantize
@@ -12,7 +11,6 @@ module Tinybucket
 
       def initialize(json)
         self.attributes = json
-        @api_config = {}
         @_loaded = !json.empty?
       end
 
@@ -50,7 +48,7 @@ module Tinybucket
       end
 
       def create_instance(klass_name, options)
-        ApiFactory.create_instance(klass_name, api_config, options)
+        ApiFactory.create_instance(klass_name, options)
       end
 
       def logger

--- a/spec/lib/tinybucket/api_factory_spec.rb
+++ b/spec/lib/tinybucket/api_factory_spec.rb
@@ -3,15 +3,14 @@ require 'spec_helper'
 RSpec.describe Tinybucket::ApiFactory do
 
   describe 'create_instance' do
-    let(:klass_name) { 'PullRequests' }
-    let(:config) { {} }
     let(:options) { {} }
 
     subject do
-      Tinybucket::ApiFactory.create_instance(klass_name, config, options)
+      Tinybucket::ApiFactory.create_instance(klass_name, options)
     end
 
     context 'with valid klass_name' do
+      let(:klass_name) { 'PullRequests' }
       it { expect(subject).to be_a_kind_of(Tinybucket::Api::BaseApi) }
     end
 

--- a/spec/lib/tinybucket/client_spec.rb
+++ b/spec/lib/tinybucket/client_spec.rb
@@ -3,26 +3,11 @@ require 'spec_helper.rb'
 RSpec.describe Tinybucket::Client do
   include ApiResponseMacros
 
-  let(:client) { Tinybucket::Client.new({}) }
+  let(:client) { Tinybucket::Client.new }
 
   describe 'new' do
-    let(:options) { {} }
-
-    context 'without block' do
-      subject { Tinybucket::Client.new(options) }
-      it { expect(subject.config).to eq(options) }
-    end
-
-    context 'with block' do
-      subject do
-        Tinybucket::Client.new do |config|
-          options.each_pair do |key, value|
-            config.send("#{key}=", value)
-          end
-        end
-      end
-      it { expect(subject.config).to eq(options) }
-    end
+    subject { Tinybucket::Client.new }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Client) }
   end
 
   describe 'repos' do
@@ -60,17 +45,17 @@ RSpec.describe Tinybucket::Client do
     context 'when invalid argument passed' do
       context 'with a integer' do
         subject { client.repos(20) }
-        it { expect { subject }.to raise_error }
+        it { expect { subject }.to raise_error(ArgumentError) }
       end
 
       context 'with a string and string' do
         subject { client.repos('test_owner', 'test_repository') }
-        it { expect { subject }.to raise_error }
+        it { expect { subject }.to raise_error(ArgumentError) }
       end
 
       context 'with three arguments' do
         subject { client.repos('a', 'b', 'c') }
-        it { expect { subject }.to raise_error }
+        it { expect { subject }.to raise_error(ArgumentError) }
       end
     end
   end

--- a/spec/lib/tinybucket_spec.rb
+++ b/spec/lib/tinybucket_spec.rb
@@ -3,31 +3,8 @@ require 'spec_helper'
 RSpec.describe Tinybucket do
 
   describe 'new' do
-    let(:options) { { key: 'value' } }
-
-    shared_examples_for 'return client which configured with options' do
-      it 'return client instance which configured with options' do
-        expect(subject).to be_instance_of(Tinybucket::Client)
-        expect(subject.config).to eq(options)
-      end
-    end
-
-    context 'when options passed' do
-      subject { Tinybucket.new(options) }
-      it_behaves_like 'return client which configured with options'
-    end
-
-    context 'when block given' do
-      subject { Tinybucket.new(&block) }
-      let(:block) do
-        lambda do |config|
-          options.each_pair do |key, value|
-            config.send("#{key}=", value)
-          end
-        end
-      end
-      it_behaves_like 'return client which configured with options'
-    end
+    subject { Tinybucket.new }
+    it { expect(subject).to be_instance_of(Tinybucket::Client) }
   end
 
   describe 'config' do
@@ -38,19 +15,25 @@ RSpec.describe Tinybucket do
   describe 'configure' do
     subject(:config) { Tinybucket.config }
     let(:logger) { Logger.new($stdout) }
+    let(:oauth_token) { 'test_oauth_token' }
+    let(:oauth_secret) { 'test_oauth_secret' }
 
-    it 'can configurable logger' do
+    it 'is configurable' do
       expect(config.logger).to be_nil
 
       expect do
         Tinybucket.configure do |config|
           config.logger = logger
+          config.oauth_token = oauth_token
+          config.oauth_secret = oauth_secret
         end
       end.not_to raise_error
 
       expect(config.logger).to eq(logger)
+      expect(config.oauth_token).to eq(oauth_token)
+      expect(config.oauth_secret).to eq(oauth_secret)
     end
 
-    after { Tinybucket.configure { |config| config.logger = nil } }
+    after { Tinybucket.instance_variable_set(:@config, nil) }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,10 +10,10 @@ require 'coveralls'
 require 'simplecov'
 Coveralls.wear!
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
-]
+])
 SimpleCov.start do
   add_filter '.bundle/'
   add_filter 'spec'


### PR DESCRIPTION
Currently (v0.17.0), All of ApiClient/Model instances has individual oauth token/secret as `@api_config`.
It makes codes un-necessary complexify...

This pull request makes these changes.

- `Tinybucket::Config` instance keeps `oauth token/secret` as `Tinybucket.config`.
   - Use `oauth token/secret` in `Tinybucket.config` when send Api request to Bitbucket.
- All of ApiClient/Model instances does not has `oauth token/secret`, any more.
