### PR TITLE
introduce enumerator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ app.rb
 log/
 *.swp
 
+features
+.envrc
+
 ## from github ignore.
 
 /.config

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,13 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 task :test => :spec
 
+if Dir.exist?('./features')
+  RSpec::Core::RakeTask.new(:features) do |t|
+    t.pattern = './features/**/*_spec.rb'
+    t.rspec_opts = '-I ./features'
+  end
+end
+
 begin
   require 'rubocop/rake_task'
   RuboCop::RakeTask.new

--- a/lib/tinybucket.rb
+++ b/lib/tinybucket.rb
@@ -14,13 +14,16 @@ require 'faraday_middleware/follow_oauth_redirects'
 require 'active_model'
 
 require 'logger'
+require 'uri'
+
+require 'tinybucket/enumerator'
+require 'tinybucket/iterator'
 
 require 'tinybucket/config'
 require 'tinybucket/null_logger'
 require 'tinybucket/api'
 require 'tinybucket/api_factory'
 require 'tinybucket/api/helper'
-require 'tinybucket/client'
 require 'tinybucket/connection'
 require 'tinybucket/constants'
 require 'tinybucket/error'
@@ -30,7 +33,7 @@ require 'tinybucket/parser'
 require 'tinybucket/request'
 require 'tinybucket/response'
 
-require 'uri'
+require 'tinybucket/client'
 
 require 'active_support/notifications'
 ActiveSupport::Notifications.subscribe('request.faraday') \

--- a/lib/tinybucket/api/branch_restrictions_api.rb
+++ b/lib/tinybucket/api/branch_restrictions_api.rb
@@ -6,12 +6,11 @@ module Tinybucket
       attr_accessor :repo_owner, :repo_slug
 
       def list(options = {})
-        list = get_path(path_to_list,
-                        options,
-                        Tinybucket::Parser::BranchRestrictionsParser)
-
-        list.next_proc = next_proc(:list, options)
-        list
+        get_path(
+          path_to_list,
+          options,
+          Tinybucket::Parser::BranchRestrictionsParser
+        )
       end
 
       def find(restriction_id, options = {})

--- a/lib/tinybucket/api/comments_api.rb
+++ b/lib/tinybucket/api/comments_api.rb
@@ -12,8 +12,6 @@ module Tinybucket
                         options,
                         Tinybucket::Parser::CommentsParser)
 
-        list.next_proc = next_proc(:list, options)
-
         associate_with_target(list)
         list
       end

--- a/lib/tinybucket/api/commits_api.rb
+++ b/lib/tinybucket/api/commits_api.rb
@@ -6,12 +6,11 @@ module Tinybucket
       attr_accessor :repo_owner, :repo_slug
 
       def list(options = {})
-        list = get_path(path_to_list,
-                        options,
-                        Tinybucket::Parser::CommitsParser)
-
-        list.next_proc = next_proc(:list, options)
-        list
+        get_path(
+          path_to_list,
+          options,
+          Tinybucket::Parser::CommitsParser
+        )
       end
 
       def find(revision, options = {})

--- a/lib/tinybucket/api/pull_requests_api.rb
+++ b/lib/tinybucket/api/pull_requests_api.rb
@@ -6,12 +6,11 @@ module Tinybucket
       attr_accessor :repo_owner, :repo_slug
 
       def list(options = {})
-        list = get_path(path_to_list,
-                        options,
-                        Tinybucket::Parser::PullRequestsParser)
-
-        list.next_proc = next_proc(:list, options)
-        list
+        get_path(
+          path_to_list,
+          options,
+          Tinybucket::Parser::PullRequestsParser
+        )
       end
 
       def find(pr_id, options = {})
@@ -23,12 +22,11 @@ module Tinybucket
       end
 
       def commits(pr_id, options = {})
-        list = get_path(path_to_commits(pr_id),
-                        options,
-                        Tinybucket::Parser::CommitsParser)
-
-        list.next_proc = next_proc(:commits, options)
-        list
+        get_path(
+          path_to_commits(pr_id),
+          options,
+          Tinybucket::Parser::CommitsParser
+        )
       end
 
       def approve(pr_id, options = {})

--- a/lib/tinybucket/api/repo_api.rb
+++ b/lib/tinybucket/api/repo_api.rb
@@ -14,21 +14,19 @@ module Tinybucket
       end
 
       def watchers(options = {})
-        list = get_path(path_to_watchers,
-                        options,
-                        Tinybucket::Parser::ProfilesParser)
-
-        list.next_proc = next_proc(:watchers, options)
-        list
+        get_path(
+          path_to_watchers,
+          options,
+          Tinybucket::Parser::ProfilesParser
+        )
       end
 
       def forks(options = {})
-        list = get_path(path_to_forks,
-                        options,
-                        Tinybucket::Parser::ReposParser)
-
-        list.next_proc = next_proc(:forks, options)
-        list
+        get_path(
+          path_to_forks,
+          options,
+          Tinybucket::Parser::ReposParser
+        )
       end
     end
   end

--- a/lib/tinybucket/api/repos_api.rb
+++ b/lib/tinybucket/api/repos_api.rb
@@ -7,12 +7,11 @@ module Tinybucket
         opts = options.clone
         opts.delete(:owner)
 
-        list = get_path(path_to_list(options),
-                        opts,
-                        Tinybucket::Parser::ReposParser)
-
-        list.next_proc = next_proc(:list, options)
-        list
+        get_path(
+          path_to_list(options),
+          opts,
+          Tinybucket::Parser::ReposParser
+        )
       end
     end
   end

--- a/lib/tinybucket/api/team_api.rb
+++ b/lib/tinybucket/api/team_api.rb
@@ -12,39 +12,35 @@ module Tinybucket
       end
 
       def members(name, options = {})
-        list = get_path(path_to_members(name),
-                        options,
-                        Tinybucket::Parser::TeamsParser)
-
-        list.next_proc = next_proc(:members, options)
-        list
+        get_path(
+          path_to_members(name),
+          options,
+          Tinybucket::Parser::TeamsParser
+        )
       end
 
       def followers(name, options = {})
-        list = get_path(path_to_followers(name),
-                        options,
-                        Tinybucket::Parser::TeamsParser)
-
-        list.next_proc = next_proc(:followers, options)
-        list
+        get_path(
+          path_to_followers(name),
+          options,
+          Tinybucket::Parser::TeamsParser
+        )
       end
 
       def following(name, options = {})
-        list = get_path(path_to_following(name),
-                        options,
-                        Tinybucket::Parser::TeamsParser)
-
-        list.next_proc = next_proc(:following, options)
-        list
+        get_path(
+          path_to_following(name),
+          options,
+          Tinybucket::Parser::TeamsParser
+        )
       end
 
       def repos(name, options = {})
-        list = get_path(path_to_repos(name),
-                        options,
-                        Tinybucket::Parser::ReposParser)
-
-        list.next_proc = next_proc(:repos, options)
-        list
+        get_path(
+          path_to_repos(name),
+          options,
+          Tinybucket::Parser::ReposParser
+        )
       end
     end
   end

--- a/lib/tinybucket/api/user_api.rb
+++ b/lib/tinybucket/api/user_api.rb
@@ -14,30 +14,27 @@ module Tinybucket
       end
 
       def followers(options = {})
-        list = get_path(path_to_followers,
-                        options,
-                        Tinybucket::Parser::ProfilesParser)
-
-        list.next_proc = next_proc(:followers, options)
-        list
+        get_path(
+          path_to_followers,
+          options,
+          Tinybucket::Parser::ProfilesParser
+        )
       end
 
       def following(options = {})
-        list = get_path(path_to_following,
-                        options,
-                        Tinybucket::Parser::ProfilesParser)
-
-        list.next_proc = next_proc(:following, options)
-        list
+        get_path(
+          path_to_following,
+          options,
+          Tinybucket::Parser::ProfilesParser
+        )
       end
 
       def repos(options = {})
-        list = get_path(path_to_repos,
-                        options,
-                        Tinybucket::Parser::ReposParser)
-
-        list.next_proc = next_proc(:repos, options)
-        list
+        get_path(
+          path_to_repos,
+          options,
+          Tinybucket::Parser::ReposParser
+        )
       end
     end
   end

--- a/lib/tinybucket/client.rb
+++ b/lib/tinybucket/client.rb
@@ -1,5 +1,7 @@
 module Tinybucket
   class Client
+    include ::Tinybucket::Model::Concerns::Enumerable
+
     # Get Repositories
     #
     # when you want to get repositories of the owner, call with owner, options.
@@ -61,8 +63,11 @@ module Tinybucket
       options = args.empty? ? {} : args.first
       raise ArgumentError unless options.is_a?(Hash)
 
-      @repos ||= create_instance('Repos')
-      @repos.list(options)
+      enumerator(
+        repos_api,
+        :list,
+        options
+      )
     end
 
     def owners_repos(*args)
@@ -70,9 +75,21 @@ module Tinybucket
       options = (args.size == 2) ? args[1] : {}
       raise ArgumentError unless options.is_a?(Hash)
 
-      @user ||= create_instance('User')
-      @user.username = owner
-      @user.repos(options)
+      enumerator(
+        user_api(owner),
+        :repos,
+        options
+      )
+    end
+
+    def repos_api
+      create_instance('Repos')
+    end
+
+    def user_api(owner)
+      api = create_instance('User')
+      api.username = owner
+      api
     end
 
     def create_instance(name)

--- a/lib/tinybucket/enumerator.rb
+++ b/lib/tinybucket/enumerator.rb
@@ -1,0 +1,31 @@
+module Tinybucket
+  class Enumerator < ::Enumerator
+    def initialize(iterator, block)
+      @iterator = iterator
+
+      super() do |y|
+        loop do
+          m = y.yield(@iterator.next)
+          m = block.call(m) if block
+          m
+        end
+      end
+
+      lazy if lazy_enumerable?
+    end
+
+    def size
+      @iterator.size
+    end
+
+    private
+
+    def lazy_enumerable?
+      ruby_major_version >= 2
+    end
+
+    def ruby_major_version
+      RUBY_VERSION.split('.')[0].to_i
+    end
+  end
+end

--- a/lib/tinybucket/iterator.rb
+++ b/lib/tinybucket/iterator.rb
@@ -1,0 +1,58 @@
+module Tinybucket
+  class Iterator
+    def initialize(api_client, method, *args)
+      @client = api_client
+      @method = method
+      @args = args
+
+      @attrs = {}
+      @values = []
+      @pos = nil
+    end
+
+    def next
+      next_value
+    end
+
+    def size
+      load_next if next?
+      @attrs[:size]
+    end
+
+    private
+
+    def next_value
+      load_next if next?
+
+      @values.fetch(@pos).tap { @pos += 1 }
+    rescue IndexError
+      raise StopIteration
+    end
+
+    def next?
+      @pos.nil? || (@values.size == @pos && @attrs[:next])
+    end
+
+    def load_next
+      @pos = 0 if @pos.nil?
+
+      page = @client.send(@method, *next_params)
+
+      @attrs = page.attrs
+      @values.concat(page.items)
+    end
+
+    def next_params
+      params =
+        if @attrs.empty?
+          {}
+        else
+          unescaped_query = URI.unescape(URI.parse(@attrs[:next]).query)
+          Hash[*unescaped_query.split(/&|=/)]
+        end
+
+      @args[-1].merge!(params)
+      @args
+    end
+  end
+end

--- a/lib/tinybucket/model/base.rb
+++ b/lib/tinybucket/model/base.rb
@@ -3,6 +3,7 @@ module Tinybucket
     class Base
       include ::ActiveModel::Serializers::JSON
       include Concerns::AcceptableAttributes
+      include Concerns::Enumerable
 
       def self.concern_included?(concern_name)
         mod_name = "Tinybucket::Model::Concerns::#{concern_name}".constantize

--- a/lib/tinybucket/model/commit.rb
+++ b/lib/tinybucket/model/commit.rb
@@ -10,7 +10,11 @@ module Tinybucket
         :message, :participants, :uuid
 
       def comments(options = {})
-        comments_api.list(options)
+        enumerator(
+          comments_api,
+          :list,
+          options
+        ) { |m| block_given? ? yield(m) : m }
       end
 
       def comment(comment_id, options = {})

--- a/lib/tinybucket/model/concerns.rb
+++ b/lib/tinybucket/model/concerns.rb
@@ -5,6 +5,7 @@ module Tinybucket
 
       [
         :AcceptableAttributes,
+        :Enumerable,
         :RepositoryKeys,
         :Reloadable
       ].each do |mod_name|

--- a/lib/tinybucket/model/concerns/enumerable.rb
+++ b/lib/tinybucket/model/concerns/enumerable.rb
@@ -1,0 +1,18 @@
+module Tinybucket
+  module Model
+    module Concerns
+      module Enumerable
+        extend ActiveSupport::Concern
+
+        included do
+          protected
+
+          def enumerator(api_client, method, *args, &block)
+            iter = Tinybucket::Iterator.new(api_client, method, *args)
+            Tinybucket::Enumerator.new(iter, block)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/model/page.rb
+++ b/lib/tinybucket/model/page.rb
@@ -1,66 +1,26 @@
 module Tinybucket
   module Model
     class Page
-      # attr_reader :size, :page, :pagelen, :next, :previous
       attr_reader :attrs
       attr_reader :items
-      attr_writer :next_proc
 
       def initialize(json, item_klass)
-        @attrs = {}
-        %w(size page pagelen next previous).each do |attr|
-          @attrs[attr.intern] = json[attr]
-        end
-
-        @items = if json['values'].present? && json['values'].is_a?(Array)
-                   json['values'].map { |hash| item_klass.new(hash) }
-                 else
-                   []
-                 end
-      end
-
-      def size
-        @attrs[:size]
-      end
-
-      def each(options = {})
-        loop do
-          start = (@attrs[:page] - 1) * @attrs[:pagelen]
-
-          @items.each_with_index do |m, i|
-            pos = start + i
-            yield(m, pos)
-
-            raise StopIteration if \
-              (!options[:limit].nil? && pos == (options[:limit] - 1))
-          end
-
-          break unless next_page?
-
-          load_next
-        end
-
-      rescue StopIteration
-        return
+        @attrs = parse_attrs(json)
+        @items = parse_values(json, item_klass)
       end
 
       private
 
-      def next_page?
-        @attrs[:next].present?
+      def parse_attrs(json)
+        %w(size page pagelen next previous).map do |attr|
+          { attr.to_sym => json[attr] }
+        end.reduce(&:merge)
       end
 
-      def load_next
-        raise StopIteration if @attrs[:next].nil? || @next_proc.nil?
+      def parse_values(json, item_klass)
+        return [] if json['values'].nil? || !json['values'].is_a?(Array)
 
-        unescaped_query = URI.unescape(URI.parse(@attrs[:next]).query)
-        query = Hash[*unescaped_query.split(/&|=/)]
-        list = @next_proc.call(query)
-
-        raise StopIteration if list.items.empty?
-
-        @attrs = list.attrs
-        @items = list.items
+        json['values'].map { |hash| item_klass.new(hash) }
       end
     end
   end

--- a/lib/tinybucket/model/profile.rb
+++ b/lib/tinybucket/model/profile.rb
@@ -8,15 +8,27 @@ module Tinybucket
         :links, :created_on, :location, :type, :uuid
 
       def followers(options = {})
-        user_api.followers(options)
+        enumerator(
+          user_api,
+          :followers,
+          options
+        ) { |m| block_given? ? yield(m) : m }
       end
 
       def following(options = {})
-        user_api.following(options)
+        enumerator(
+          user_api,
+          :following,
+          options
+        ) { |m| block_given? ? yield(m) : m }
       end
 
       def repos(options = {})
-        user_api.repos(options)
+        enumerator(
+          user_api,
+          :repos,
+          options
+        ) { |m| block_given? ? yield(m) : m }
       end
 
       private

--- a/lib/tinybucket/model/pull_request.rb
+++ b/lib/tinybucket/model/pull_request.rb
@@ -31,11 +31,20 @@ module Tinybucket
       end
 
       def commits(options = {})
-        pull_request_api.commits(id, options)
+        enumerator(
+          pull_request_api,
+          :commits,
+          id,
+          options
+        ) { |m| block_given? ? yield(m) : m }
       end
 
       def comments(options = {})
-        comment_api.list(options)
+        enumerator(
+          comment_api,
+          :list,
+          options
+        ) { |m| block_given? ? yield(m) : m }
       end
 
       def comment(comment_id, options = {})

--- a/lib/tinybucket/model/repository.rb
+++ b/lib/tinybucket/model/repository.rb
@@ -18,8 +18,14 @@ module Tinybucket
       end
 
       def pull_requests(options = {})
-        list = pull_requests_api.list(options)
-        inject_repo_keys(list)
+        enumerator(
+          pull_requests_api,
+          :list,
+          options
+        ) do |m|
+          inject_repo_keys(m)
+          block_given? ? yield(m) : m
+        end
       end
 
       def pull_request(pullrequest_id = nil, options = {})
@@ -32,16 +38,36 @@ module Tinybucket
       end
 
       def watchers(options = {})
-        repo_api.watchers(options)
+        enumerator(
+          repo_api,
+          :watchers,
+          options
+        ) do |m|
+          inject_repo_keys(m)
+          block_given? ? yield(m) : m
+        end
       end
 
       def forks(options = {})
-        repo_api.forks(options)
+        enumerator(
+          repo_api,
+          :forks,
+          options
+        ) do |m|
+          inject_repo_keys(m)
+          block_given? ? yield(m) : m
+        end
       end
 
       def commits(options = {})
-        list = commits_api.list(options)
-        inject_repo_keys(list)
+        enumerator(
+          commits_api,
+          :list,
+          options
+        ) do |m|
+          inject_repo_keys(m)
+          block_given? ? yield(m) : m
+        end
       end
 
       def commit(revision, options = {})
@@ -50,8 +76,14 @@ module Tinybucket
       end
 
       def branch_restrictions(options = {})
-        list = restrictions_api.list(options)
-        inject_repo_keys(list)
+        enumerator(
+          restrictions_api,
+          :list,
+          options
+        ) do |m|
+          inject_repo_keys(m)
+          block_given? ? yield(m) : m
+        end
       end
 
       def branch_restriction(restriction_id, options = {})

--- a/lib/tinybucket/model/team.rb
+++ b/lib/tinybucket/model/team.rb
@@ -8,19 +8,39 @@ module Tinybucket
         :links, :created_on, :location, :type
 
       def members(options = {})
-        team_api.members(username, options)
+        enumerator(
+          team_api,
+          :members,
+          username,
+          options
+        ) { |m| block_given? ? yield(m) : m }
       end
 
       def followers(options = {})
-        team_api.followers(username, options)
+        enumerator(
+          team_api,
+          :followers,
+          username,
+          options
+        ) { |m| block_given? ? yield(m) : m }
       end
 
       def following(options = {})
-        team_api.following(username, options)
+        enumerator(
+          team_api,
+          :following,
+          username,
+          options
+        ) { |m| block_given? ? yield(m) : m }
       end
 
       def repos(options = {})
-        team_api.repos(username, options)
+        enumerator(
+          team_api,
+          :repos,
+          username,
+          options
+        ) { |m| block_given? ? yield(m) : m }
       end
 
       private

--- a/spec/lib/tinybucket/api/team_api_spec.rb
+++ b/spec/lib/tinybucket/api/team_api_spec.rb
@@ -79,5 +79,4 @@ RSpec.describe Tinybucket::Api::TeamApi do
       it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
     end
   end
-
 end

--- a/spec/lib/tinybucket/api/user_api_spec.rb
+++ b/spec/lib/tinybucket/api/user_api_spec.rb
@@ -56,4 +56,18 @@ RSpec.describe Tinybucket::Api::UserApi do
       it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
     end
   end
+
+  describe 'repos' do
+    subject { api.repos }
+
+    context 'when without username' do
+      let(:user) { nil }
+      it { expect { subject }.to raise_error(ArgumentError) }
+    end
+
+    context 'when with username' do
+      let(:request_path) { "/repositories/#{user}" }
+      it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
+    end
+  end
 end

--- a/spec/lib/tinybucket/client_spec.rb
+++ b/spec/lib/tinybucket/client_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe Tinybucket::Client do
 
       context 'without options' do
         subject { client.repos }
-        it { expect(subject).to be_instance_of(Tinybucket::Model::Page) }
+        it { expect(subject).to be_instance_of(Tinybucket::Enumerator) }
       end
       context 'with options' do
         subject { client.repos(options) }
         let(:options) { {} }
-        it { expect(subject).to be_instance_of(Tinybucket::Model::Page) }
+        it { expect(subject).to be_instance_of(Tinybucket::Enumerator) }
       end
     end
 
@@ -32,13 +32,13 @@ RSpec.describe Tinybucket::Client do
       context 'without options' do
         let(:request_path) { "/repositories/#{owner}" }
         subject { client.repos(owner) }
-        it { expect(subject).to be_instance_of(Tinybucket::Model::Page) }
+        it { expect(subject).to be_instance_of(Tinybucket::Enumerator) }
       end
       context 'with options' do
         let(:request_path) { "/repositories/#{owner}" }
         subject { client.repos(owner, options) }
         let(:options) { {} }
-        it { expect(subject).to be_instance_of(Tinybucket::Model::Page) }
+        it { expect(subject).to be_instance_of(Tinybucket::Enumerator) }
       end
     end
 

--- a/spec/lib/tinybucket/model/commit_spec.rb
+++ b/spec/lib/tinybucket/model/commit_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Tinybucket::Model::Commit do
       "/repositories/#{owner}/#{slug}/commit/1/comments"
     end
     subject { model.comments }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
   end
 
   describe '#comment' do

--- a/spec/lib/tinybucket/model/page_spec.rb
+++ b/spec/lib/tinybucket/model/page_spec.rb
@@ -25,34 +25,4 @@ RSpec.describe Tinybucket::Model::Page do
       expect(subject.items.size).to eq(json['values'].size)
     end
   end
-
-  describe 'size' do
-    subject { model.size }
-
-    let(:base_json) do
-      text = File.read('spec/fixtures/repositories/get.json')
-      JSON.parse(text)
-    end
-
-    context 'when json contains size = nil' do
-      let(:json) do
-        base_json['size'] = nil
-        base_json
-      end
-      it { expect(subject).to be_nil }
-    end
-
-    context 'when json contains size' do
-      let(:size) { 1000 }
-      let(:json) do
-        base_json['size'] = size
-        base_json
-      end
-      it { expect(subject).to eq(size) }
-    end
-  end
-
-  describe 'each' do
-    pending 'TODO add specs'
-  end
 end

--- a/spec/lib/tinybucket/model/profile_spec.rb
+++ b/spec/lib/tinybucket/model/profile_spec.rb
@@ -35,18 +35,18 @@ RSpec.describe Tinybucket::Model::Profile do
   describe 'followers' do
     let(:request_path) { "/users/#{username}/followers" }
     subject { model.followers() }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
   end
 
   describe 'following' do
     let(:request_path) { "/users/#{username}/following" }
     subject { model.following }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
   end
 
   describe 'repos' do
     let(:request_path) { "/repositories/#{username}" }
     subject { model.repos }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
   end
 end

--- a/spec/lib/tinybucket/model/pull_request_spec.rb
+++ b/spec/lib/tinybucket/model/pull_request_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Tinybucket::Model::PullRequest do
 
     subject { model.commits() }
 
-    it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
   end
 
   describe 'comments' do
@@ -104,9 +104,15 @@ RSpec.describe Tinybucket::Model::PullRequest do
 
     subject { model.comments }
 
-    it 'return comment list' do
-      expect(subject).to be_an_instance_of(Tinybucket::Model::Page)
-      subject.items.each do |comment|
+    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
+    it 'return comments which associate with this pull request' do
+      # extract iterator from enumerator.
+      iterator = subject.instance_variable_get(:@iterator)
+      # extract values from iterator.
+      values = iterator.instance_variable_get(:@values)
+
+      values.each do |comment|
+        expect(comment).to be_an_instance_of(Tinybucket::Model::Comment)
         expect(comment.commented_to).to eq(model)
       end
     end

--- a/spec/lib/tinybucket/model/repository_spec.rb
+++ b/spec/lib/tinybucket/model/repository_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Tinybucket::Model::Repository do
 
     subject { model.pull_requests() }
 
-    it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
   end
 
   describe '#pull_request' do
@@ -80,19 +80,19 @@ RSpec.describe Tinybucket::Model::Repository do
   describe '#watchers' do
     let(:request_path) { "/repositories/#{owner}/#{slug}/watchers" }
     subject { model.watchers }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
   end
 
   describe '#forks' do
     let(:request_path) { "/repositories/#{owner}/#{slug}/forks" }
     subject { model.forks }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
   end
 
   describe '#commits' do
     let(:request_path) { "/repositories/#{owner}/#{slug}/commits" }
     subject { model.commits }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
   end
 
   describe '#commit' do
@@ -105,7 +105,7 @@ RSpec.describe Tinybucket::Model::Repository do
   describe '#branch_restrictions' do
     let(:request_path) { "/repositories/#{owner}/#{slug}/branch-restrictions" }
     subject { model.branch_restrictions }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
   end
 
   describe '#branch_restriction' do

--- a/spec/lib/tinybucket/model/team_spec.rb
+++ b/spec/lib/tinybucket/model/team_spec.rb
@@ -35,24 +35,24 @@ RSpec.describe Tinybucket::Model::Team do
   describe '#members' do
     let(:request_path) { "/teams/#{teamname}/members" }
     subject { model.members }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
   end
 
   describe '#followers' do
     let(:request_path) { "/teams/#{teamname}/followers" }
     subject { model.followers() }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
   end
 
   describe '#following' do
     let(:request_path) { "/teams/#{teamname}/following" }
     subject { model.following }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
   end
 
   describe '#repos' do
     let(:request_path) { "/teams/#{teamname}/repositories" }
     subject { model.repos }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
 SimpleCov.start do
   add_filter '.bundle/'
   add_filter 'spec'
+  add_filter 'features'
 end
 
 if ENV['CODECLIMATE_REPORT']


### PR DESCRIPTION
This pull request introduce `Tinybucket::Enumerator` to be enumerable each resources.

# At v0.1.7

At v0.1.7, user can only `each` method like this.

```
bucket = Tinybucket.new(oauth_token: 'xxx', oauth_secret: 'xxx')
bucker.repos('my_name').each do |repo|
   # some thind to do with repo
end
```

It's not converient...

# Changes

This pull request introduce `Tinybucket::Enumerator` which inherit [ruby's Enumerator](http://ruby-doc.org/core-2.2.0/Enumerator.html).

`Tinybucket::Enumerator` contains `Tinybucket::Iterator` instance which manage Bitbucket REST API call for pagination, insted of `Tinybucket::Model::Page`.

User can use enumerator feature like this.

```
bucket = Tinybucket.new

# only with 1 api request 
p bucket.repo('hirakiuc').size
=> 5

p bucket.repos('hirakiuc', 'xxx').to_a
=> (showed repositories as array)

merged_prs = bucket.repos('hirakiuc', 'xxx').pull_requests(state: 'MERGED').map(&:title)
=> (pull request's titles array)

p bucker.repos('hirakiuc', 'xxx').size
=> 4 (show counts with only a api request)
```