### PR TITLE
remove api class option.

### DIFF
--- a/lib/tinybucket/api/base_api.rb
+++ b/lib/tinybucket/api/base_api.rb
@@ -3,16 +3,6 @@ module Tinybucket
     class BaseApi
       include Tinybucket::Connection
       include Tinybucket::Request
-
-      def initialize(options = {})
-        @options = options
-      end
-
-      protected
-
-      def option(key)
-        @options[key.intern]
-      end
     end
   end
 end

--- a/lib/tinybucket/api_factory.rb
+++ b/lib/tinybucket/api_factory.rb
@@ -1,9 +1,7 @@
 module Tinybucket
   class ApiFactory
     class << self
-      def create_instance(klass_name, options)
-        options.symbolize_keys!
-
+      def create_instance(klass_name)
         klass =
           begin
             name = "#{klass_name}Api".intern
@@ -14,7 +12,7 @@ module Tinybucket
             raise ArgumentError, 'must provide klass to be instantiated'
           end
 
-        klass.new options
+        klass.new
       end
     end
   end

--- a/lib/tinybucket/client.rb
+++ b/lib/tinybucket/client.rb
@@ -61,7 +61,7 @@ module Tinybucket
       options = args.empty? ? {} : args.first
       raise ArgumentError unless options.is_a?(Hash)
 
-      @repos ||= create_instance('Repos', options)
+      @repos ||= create_instance('Repos')
       @repos.list(options)
     end
 
@@ -70,13 +70,13 @@ module Tinybucket
       options = (args.size == 2) ? args[1] : {}
       raise ArgumentError unless options.is_a?(Hash)
 
-      @user ||= create_instance('User', options)
+      @user ||= create_instance('User')
       @user.username = owner
       @user.repos(options)
     end
 
-    def create_instance(name, options)
-      ApiFactory.create_instance(name, options)
+    def create_instance(name)
+      ApiFactory.create_instance(name)
     end
   end
 end

--- a/lib/tinybucket/model/base.rb
+++ b/lib/tinybucket/model/base.rb
@@ -34,12 +34,12 @@ module Tinybucket
 
       protected
 
-      def create_api(api_key, keys, options)
+      def create_api(api_key, keys)
         key = ('@' + api_key.underscore).intern
         api = instance_variable_get(key)
         return api if api.present?
 
-        api = create_instance(api_key, options)
+        api = create_instance(api_key)
         api.repo_owner = keys[:repo_owner]
         api.repo_slug  = keys[:repo_slug]
         instance_variable_set(key, api)
@@ -47,8 +47,8 @@ module Tinybucket
         api
       end
 
-      def create_instance(klass_name, options)
-        ApiFactory.create_instance(klass_name, options)
+      def create_instance(klass_name)
+        ApiFactory.create_instance(klass_name)
       end
 
       def logger

--- a/lib/tinybucket/model/comment.rb
+++ b/lib/tinybucket/model/comment.rb
@@ -13,20 +13,20 @@ module Tinybucket
       private
 
       def commit_api
-        create_api('Comments', repo_keys, options)
+        create_api('Comments', repo_keys)
       end
 
-      def pull_request_api(options)
-        create_api('PullRequests', repo_keys, options)
+      def pull_request_api
+        create_api('PullRequests', repo_keys)
       end
 
       def load_model
         api =
           case commented_to
           when Tinybucket::Model::Commit
-            commit_api({})
+            commit_api
           when Tinybucket::Model::PullRequest
-            pull_request_api({})
+            pull_request_api
           else
             raise ArgumentError, 'commented_to was invalid'
           end

--- a/lib/tinybucket/model/commit.rb
+++ b/lib/tinybucket/model/commit.rb
@@ -10,29 +10,29 @@ module Tinybucket
         :message, :participants, :uuid
 
       def comments(options = {})
-        comments_api(options).list(options)
+        comments_api.list(options)
       end
 
       def comment(comment_id, options = {})
-        comments_api(options).find(comment_id, options)
+        comments_api.find(comment_id, options)
       end
 
       private
 
-      def comments_api(options)
+      def comments_api
         raise ArgumentError, MISSING_REPOSITORY_KEY unless repo_keys?
 
-        api = create_api('Comments', repo_keys, options)
+        api = create_api('Comments', repo_keys)
         api.commented_to = self
         api
       end
 
-      def commit_api(options)
-        create_api 'Commits', repo_keys, options
+      def commit_api
+        create_api('Commits', repo_keys)
       end
 
       def load_model
-        commit_api({}).find(hash)
+        commit_api.find(hash)
       end
     end
   end

--- a/lib/tinybucket/model/profile.rb
+++ b/lib/tinybucket/model/profile.rb
@@ -8,29 +8,29 @@ module Tinybucket
         :links, :created_on, :location, :type, :uuid
 
       def followers(options = {})
-        user_api(options).followers(options)
+        user_api.followers(options)
       end
 
       def following(options = {})
-        user_api(options).following(options)
+        user_api.following(options)
       end
 
       def repos(options = {})
-        user_api(options).repos(options)
+        user_api.repos(options)
       end
 
       private
 
-      def user_api(options)
+      def user_api
         return @user if @user
 
-        @user = create_instance 'User', options
+        @user = create_instance('User')
         @user.username = username
         @user
       end
 
       def load_model
-        user_api({}).profile
+        user_api.profile
       end
     end
   end

--- a/lib/tinybucket/model/pull_request.rb
+++ b/lib/tinybucket/model/pull_request.rb
@@ -19,53 +19,53 @@ module Tinybucket
       end
 
       def decline(options = {})
-        pull_request_api(options).decline(id, options)
+        pull_request_api.decline(id, options)
       end
 
       def approve(options = {})
-        pull_request_api(options).approve(id, options)
+        pull_request_api.approve(id, options)
       end
 
       def unapprove(options = {})
-        pull_request_api(options).unapprove(id, options)
+        pull_request_api.unapprove(id, options)
       end
 
       def commits(options = {})
-        pull_request_api(options).commits(id, options)
+        pull_request_api.commits(id, options)
       end
 
       def comments(options = {})
-        comment_api(options).list(options)
+        comment_api.list(options)
       end
 
       def comment(comment_id, options = {})
-        comment_api(options).find(comment_id, options)
+        comment_api.find(comment_id, options)
       end
 
       def diff(options = {})
-        pull_request_api(options).diff(id, options)
+        pull_request_api.diff(id, options)
       end
 
       def merge(options = {})
-        pull_request_api(options).merge(id, options)
+        pull_request_api.merge(id, options)
       end
 
       private
 
-      def comment_api(options)
-        api = create_api('Comments', repo_keys, options)
+      def comment_api
+        api = create_api('Comments', repo_keys)
         api.commented_to = self
         api
       end
 
-      def pull_request_api(options)
+      def pull_request_api
         raise ArgumentError, MISSING_REPOSITORY_KEY unless repo_keys?
 
-        create_api('PullRequests', repo_keys, options)
+        create_api('PullRequests', repo_keys)
       end
 
       def load_model
-        pull_request_api({}).find(id)
+        pull_request_api.find(id)
       end
     end
   end

--- a/lib/tinybucket/model/repository.rb
+++ b/lib/tinybucket/model/repository.rb
@@ -18,13 +18,13 @@ module Tinybucket
       end
 
       def pull_requests(options = {})
-        list = pull_requests_api(options).list(options)
+        list = pull_requests_api.list(options)
         inject_repo_keys(list)
       end
 
       def pull_request(pullrequest_id = nil, options = {})
         m = if pullrequest_id.present?
-              pull_requests_api(options).find(pullrequest_id, options)
+              pull_requests_api.find(pullrequest_id, options)
             else
               Tinybucket::Model::PullRequest.new({})
             end
@@ -32,65 +32,65 @@ module Tinybucket
       end
 
       def watchers(options = {})
-        repo_api(options).watchers(options)
+        repo_api.watchers(options)
       end
 
       def forks(options = {})
-        repo_api(options).forks(options)
+        repo_api.forks(options)
       end
 
       def commits(options = {})
-        list = commits_api(options).list(options)
+        list = commits_api.list(options)
         inject_repo_keys(list)
       end
 
       def commit(revision, options = {})
-        m = commits_api(options).find(revision, options)
+        m = commits_api.find(revision, options)
         inject_repo_keys(m)
       end
 
       def branch_restrictions(options = {})
-        list = restrictions_api(options).list(options)
+        list = restrictions_api.list(options)
         inject_repo_keys(list)
       end
 
       def branch_restriction(restriction_id, options = {})
-        m = restrictions_api(options).find(restriction_id, options)
+        m = restrictions_api.find(restriction_id, options)
         inject_repo_keys(m)
       end
 
       def diff(spec, options = {})
-        diff_api(options).find(spec, options)
+        diff_api.find(spec, options)
       end
 
       def patch(spec, options = {})
-        diff_api(options).find_patch(spec, options)
+        diff_api.find_patch(spec, options)
       end
 
       private
 
-      def pull_requests_api(options)
-        create_api('PullRequests', repo_keys, options)
+      def pull_requests_api
+        create_api('PullRequests', repo_keys)
       end
 
-      def repo_api(options)
-        create_api('Repo', repo_keys, options)
+      def repo_api
+        create_api('Repo', repo_keys)
       end
 
-      def commits_api(options)
-        create_api('Commits', repo_keys, options)
+      def commits_api
+        create_api('Commits', repo_keys)
       end
 
-      def restrictions_api(options)
-        create_api('BranchRestrictions', repo_keys, options)
+      def restrictions_api
+        create_api('BranchRestrictions', repo_keys)
       end
 
-      def diff_api(options)
-        create_api('Diff', repo_keys, options)
+      def diff_api
+        create_api('Diff', repo_keys)
       end
 
       def load_model
-        repo_api({}).find()
+        repo_api.find()
       end
     end
   end

--- a/lib/tinybucket/model/team.rb
+++ b/lib/tinybucket/model/team.rb
@@ -8,31 +8,30 @@ module Tinybucket
         :links, :created_on, :location, :type
 
       def members(options = {})
-        team_api(options).members(username, options)
+        team_api.members(username, options)
       end
 
       def followers(options = {})
-        team_api(options).followers(username, options)
+        team_api.followers(username, options)
       end
 
       def following(options = {})
-        team_api(options).following(username, options)
+        team_api.following(username, options)
       end
 
       def repos(options = {})
-        team_api(options).repos(username, options)
+        team_api.repos(username, options)
       end
 
       private
 
-      def team_api(options)
+      def team_api
         return @team if @team
-
-        @team = create_instance 'Team', options
+        @team = create_instance('Team')
       end
 
       def load_model
-        team_api({}).find(username)
+        team_api.find(username)
       end
     end
   end

--- a/spec/lib/tinybucket/api/branch_restrictions_api_spec.rb
+++ b/spec/lib/tinybucket/api/branch_restrictions_api_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe Tinybucket::Api::BranchRestrictionsApi do
   let(:slug) { 'test_repo' }
   let(:request_path) { nil }
 
-  let(:api_config) { {} }
   let(:api) do
-    api = Tinybucket::Api::BranchRestrictionsApi.new(api_config)
+    api = Tinybucket::Api::BranchRestrictionsApi.new
     api.repo_owner = owner
     api.repo_slug = slug
     api

--- a/spec/lib/tinybucket/api/comments_api_spec.rb
+++ b/spec/lib/tinybucket/api/comments_api_spec.rb
@@ -27,9 +27,8 @@ RSpec.describe Tinybucket::Api::CommentsApi do
   end
 
   let(:commented_to) { nil }
-  let(:api_config) { {} }
   let(:api) do
-    api = Tinybucket::Api::CommentsApi.new(api_config)
+    api = Tinybucket::Api::CommentsApi.new
     api.repo_owner = owner
     api.repo_slug = slug
     api.commented_to = commented_to if commented_to.present?

--- a/spec/lib/tinybucket/api/commits_api_spec.rb
+++ b/spec/lib/tinybucket/api/commits_api_spec.rb
@@ -8,9 +8,8 @@ RSpec.describe Tinybucket::Api::CommitsApi do
   let(:slug)  { 'test_repo' }
   let(:options) { {} }
 
-  let(:api_config) { {} }
   let(:api) do
-    api = Tinybucket::Api::CommitsApi.new(api_config)
+    api = Tinybucket::Api::CommitsApi.new
     api.repo_owner = owner
     api.repo_slug  = slug
     api

--- a/spec/lib/tinybucket/api/pull_requests_api_spec.rb
+++ b/spec/lib/tinybucket/api/pull_requests_api_spec.rb
@@ -3,9 +3,8 @@ require 'spec_helper'
 RSpec.describe Tinybucket::Api::PullRequestsApi do
   include ApiResponseMacros
 
-  let(:api_config) { {} }
   let(:api) do
-    api = Tinybucket::Api::PullRequestsApi.new(api_config)
+    api = Tinybucket::Api::PullRequestsApi.new
     api.repo_owner = owner
     api.repo_slug = slug
     api

--- a/spec/lib/tinybucket/api/repo_api_spec.rb
+++ b/spec/lib/tinybucket/api/repo_api_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe Tinybucket::Api::RepoApi do
   let(:repo_slug) { 'test_repo' }
   let(:request_path) { nil }
 
-  let(:api_config) { {} }
   let(:api) do
-    api = Tinybucket::Api::RepoApi.new(api_config)
+    api = Tinybucket::Api::RepoApi.new
     api.repo_owner = repo_owner
     api.repo_slug  = repo_slug
     api

--- a/spec/lib/tinybucket/api/repos_api_spec.rb
+++ b/spec/lib/tinybucket/api/repos_api_spec.rb
@@ -3,8 +3,7 @@ require 'spec_helper.rb'
 RSpec.describe Tinybucket::Api::ReposApi do
   include ApiResponseMacros
 
-  let(:api_config) { {} }
-  let(:api) { Tinybucket::Api::ReposApi.new(api_config) }
+  let(:api) { Tinybucket::Api::ReposApi.new }
 
   it { expect(api).to be_a_kind_of(Tinybucket::Api::BaseApi) }
 

--- a/spec/lib/tinybucket/api/team_api_spec.rb
+++ b/spec/lib/tinybucket/api/team_api_spec.rb
@@ -3,11 +3,7 @@ require 'spec_helper'
 RSpec.describe Tinybucket::Api::TeamApi do
   include ApiResponseMacros
 
-  let(:api_config) { {} }
-  let(:api) do
-    Tinybucket::Api::TeamApi.new(api_config)
-  end
-
+  let(:api) { Tinybucket::Api::TeamApi.new }
   let(:teamname) { 'test_team' }
   let(:request_path) { nil }
   before { stub_apiresponse(:get, request_path) if request_path }

--- a/spec/lib/tinybucket/api/user_api_spec.rb
+++ b/spec/lib/tinybucket/api/user_api_spec.rb
@@ -3,9 +3,8 @@ require 'spec_helper'
 RSpec.describe Tinybucket::Api::UserApi do
   include ApiResponseMacros
 
-  let(:api_config) { {} }
   let(:api) do
-    api = Tinybucket::Api::UserApi.new(api_config)
+    api = Tinybucket::Api::UserApi.new
     api.username = user
     api
   end

--- a/spec/lib/tinybucket/api_factory_spec.rb
+++ b/spec/lib/tinybucket/api_factory_spec.rb
@@ -3,11 +3,7 @@ require 'spec_helper'
 RSpec.describe Tinybucket::ApiFactory do
 
   describe 'create_instance' do
-    let(:options) { {} }
-
-    subject do
-      Tinybucket::ApiFactory.create_instance(klass_name, options)
-    end
+    subject { Tinybucket::ApiFactory.create_instance(klass_name) }
 
     context 'with valid klass_name' do
       let(:klass_name) { 'PullRequests' }


### PR DESCRIPTION
Api Class constructor require `options` argument.

But the `options` is not used ....

This pull request remove the `options` argument.