### PR TITLE
Reloadable BranchRestriction model.

### DIFF
--- a/lib/tinybucket/model/base.rb
+++ b/lib/tinybucket/model/base.rb
@@ -4,6 +4,7 @@ module Tinybucket
       include ::ActiveModel::Serializers::JSON
       include Concerns::AcceptableAttributes
       include Concerns::Enumerable
+      include Concerns::Reloadable
 
       def self.concern_included?(concern_name)
         mod_name = "Tinybucket::Model::Concerns::#{concern_name}".constantize

--- a/lib/tinybucket/model/comment.rb
+++ b/lib/tinybucket/model/comment.rb
@@ -27,7 +27,6 @@ module Tinybucket
     #   @return [NillClass]
     class Comment < Base
       include Tinybucket::Model::Concerns::RepositoryKeys
-      include Tinybucket::Model::Concerns::Reloadable
 
       acceptable_attributes \
         :links, :id, :parent, :filename, :content, :user, :inline, \

--- a/lib/tinybucket/model/commit.rb
+++ b/lib/tinybucket/model/commit.rb
@@ -25,7 +25,6 @@ module Tinybucket
     #   @return [NillClass]
     class Commit < Base
       include Tinybucket::Model::Concerns::RepositoryKeys
-      include Tinybucket::Model::Concerns::Reloadable
       include Tinybucket::Constants
 
       acceptable_attributes \

--- a/lib/tinybucket/model/error_response.rb
+++ b/lib/tinybucket/model/error_response.rb
@@ -15,7 +15,7 @@ module Tinybucket
     #   @return [String]
     # @!attribute [rw] uuid
     #   @return [NillClass]
-    class ErrorResponse < Base
+    class ErrorResponse
       acceptable_attributes :message, :fields, :detail, :id, :uuid
     end
   end

--- a/lib/tinybucket/model/profile.rb
+++ b/lib/tinybucket/model/profile.rb
@@ -24,8 +24,6 @@ module Tinybucket
     # @!attribute [rw] uuid
     #   @return [String]
     class Profile < Base
-      include Tinybucket::Model::Concerns::Reloadable
-
       acceptable_attributes \
         :username, :kind, :website, :display_name,
         :links, :created_on, :location, :type, :uuid

--- a/lib/tinybucket/model/pull_request.rb
+++ b/lib/tinybucket/model/pull_request.rb
@@ -41,7 +41,6 @@ module Tinybucket
     #   @return [NillClass]
     class PullRequest < Base
       include Tinybucket::Model::Concerns::RepositoryKeys
-      include Tinybucket::Model::Concerns::Reloadable
       include Tinybucket::Constants
 
       acceptable_attributes \

--- a/lib/tinybucket/model/repository.rb
+++ b/lib/tinybucket/model/repository.rb
@@ -39,7 +39,6 @@ module Tinybucket
     #   @return [String]
     class Repository < Base
       include Tinybucket::Model::Concerns::RepositoryKeys
-      include Tinybucket::Model::Concerns::Reloadable
 
       acceptable_attributes \
         :scm, :has_wiki, :description, :links, :updated_on,

--- a/lib/tinybucket/model/team.rb
+++ b/lib/tinybucket/model/team.rb
@@ -24,8 +24,6 @@ module Tinybucket
     # @!attribute [rw] type
     #   @return [String]
     class Team < Base
-      include Tinybucket::Model::Concerns::Reloadable
-
       acceptable_attributes \
         :username, :kind, :website, :display_name, :uuid,
         :links, :created_on, :location, :type


### PR DESCRIPTION
Fix #66 .

Reloadable models already include `Tinybucket::Model::Concerns::Reloadable`.

So, this pull request change like this.
- Include `Tinybucket::Model::Concerns::Reloadable` on Base Model.
- Now, ErrorResponse Model does not inherit Base Model.
  - ErrorResponse model does not require Reloadable feature.