### PR TITLE
Introduce resource model

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,17 @@ repos  = bucket.repos('someone')
 
 ##### repository Resource
 
+###### Collection Methods
+
+```ruby
+repos = bucket.repos('myname')
+
+# [ ] POST a new repository
+repos.create(params)
+```
+
+###### Object Methods
+
 ```ruby
 # [x] GET a repository
 repo = bucket.repo('someone', 'great_repo')
@@ -142,11 +153,8 @@ repo = bucket.repo('someone', 'great_repo')
 # (Load the repository attributes from Bitbucket WebAPI)
 repo.load
 
-# [ ] POST a new repository
-    repo.create(params)
-
 # [ ] DELETE a repository
-    repo.destroy
+repo.destroy
 
 # [x] GET a list of watchers
 watchers = repo.watchers
@@ -157,44 +165,52 @@ repos = repo.forks
 
 ##### pullrequests Resource
 
+###### Collection Methods
+
 ```ruby
 repo = bucket.repo('someone', 'great_repo')
 
-# [x] GET a list of open pull requests
+# [x ] GET a list of pull requests
 pull_requests = repo.pull_requests(options)
 
-# [x] GET a specific pull request
-pull_request   = repo.pull_request(pr_id)
-
 # [ ] POST (create) a new pull request
-     repo.pull_request.create(params)
+pull_requests.create(params)
+
+# [ ] GET the log of all of a repository's pull request activity
+activities = pull_requests.activities(options)
+```
+
+###### Object Methods
+
+```ruby
+repo = bucket.repo('someone', 'great_repo')
+
+# [x] GET a specific pull request
+pull_request = repo.pull_request(pr_id)
 
 # [ ] PUT a pull request update
-     repo.pull_request(pr_id).update(params)
+pull_request.update(params)
 
 # [x] GET the commits for a pull request
 commits = pull_request.commits
 
 # [x] POST a pull request approval
-          pull_request.approve
+pull_request.approve
 
 # [x] DELETE a pull request approval
-          pull_request.unapprove
+pull_request.unapprove
 
 # [x] GET the diff for a pull request
 diff = pull_request.diff
-
-# [ ] GET the log of all of a repository's pull request activity
-activities = repo.pull_requests_activities(options) # TODO: fix method name.
 
 # [ ] GET the activity for a pull request
 activities = pull_request.activities(options)
 
 # [x] Accept and merge a pull request
-             pull_request.merge(options)
+pull_request.merge(options)
 
 # [x] Decline or reject a pull request
-             pull_request.decline(options)
+pull_request.decline(options)
 
 # [x] GET a list of pull request comments
 comments = pull_request.comments
@@ -205,12 +221,20 @@ comment = pull_request.comment(comment_id)
 
 ##### commits or commit Resource
 
+###### Collection Methods
+
 ```ruby
 repo = bucket.repo('someone', 'great_repo')
 
 # [x] GET a commits list for a repository or compare commits across branches
 # branchortag, include, exclude options
 commits = repo.commits(options)
+```
+
+###### Object Methods
+
+```ruby
+repo = bucket.repo('someone', 'great_repo')
 
 # [x] GET an individual commit
 commit = repo.commit('revision')
@@ -222,13 +246,15 @@ comments = commit.comments
 comment = commit.comment(comment_id)
 
 # [x] POST a commit approval
-  commit.approve
+commit.approve
 
 # [x] DELETE a commit approval
-  commit.unapprove
+commit.unapprove
 ```
 
 ##### branch-restrictions Resource
+
+###### Collection Methods
 
 ```ruby
 repo = bucket.repo('someone', 'great_repo').find
@@ -237,16 +263,22 @@ repo = bucket.repo('someone', 'great_repo').find
 restrictions = repo.branch_restrictions
 
 # [ ] POST the branch-restrictions
-  repo.create_branch_restrictions(restrictions)
+new_restriction = restrictions.create(params)
+```
+
+###### Object Methods
+
+```ruby
+repo = bucket.repo('someone', 'great_repo').find
 
 # [x] GET a specific restriction
 restriction = repo.branch_restriction(restriction_id)
 
 # [ ] PUT a branch restriction update
-  restriction.update(params)
+restriction.update(params)
 
 # [ ] DELETE the branch restriction
-  restriction.destroy
+restriction.destroy
 ```
 
 ##### diff Resource

--- a/lib/tinybucket.rb
+++ b/lib/tinybucket.rb
@@ -31,6 +31,7 @@ require 'tinybucket/model/concerns'
 require 'tinybucket/model'
 require 'tinybucket/parser'
 require 'tinybucket/request'
+require 'tinybucket/resource'
 require 'tinybucket/response'
 
 require 'tinybucket/client'

--- a/lib/tinybucket/enumerator.rb
+++ b/lib/tinybucket/enumerator.rb
@@ -10,12 +10,13 @@ module Tinybucket
     # @param block [Proc] a proc object to handle each item.
     def initialize(iterator, block)
       @iterator = iterator
+      @block = block
 
       super() do |y|
         loop do
-          m = y.yield(@iterator.next)
-          m = block.call(m) if block
-          m
+          v = @iterator.next
+          m = @block ? @block.call(v) : v
+          y.yield(m)
         end
       end
 

--- a/lib/tinybucket/model.rb
+++ b/lib/tinybucket/model.rb
@@ -5,8 +5,8 @@ module Tinybucket
     [
       :Base,
       :BranchRestriction,
-      :Commit,
       :Comment,
+      :Commit,
       :ErrorResponse,
       :Page,
       :Profile,

--- a/lib/tinybucket/model/base.rb
+++ b/lib/tinybucket/model/base.rb
@@ -5,6 +5,7 @@ module Tinybucket
       include Concerns::AcceptableAttributes
       include Concerns::Enumerable
       include Concerns::Reloadable
+      include Concerns::ApiCallable
 
       def self.concern_included?(concern_name)
         mod_name = "Tinybucket::Model::Concerns::#{concern_name}".constantize
@@ -35,23 +36,6 @@ module Tinybucket
       end
 
       protected
-
-      def create_api(api_key, keys)
-        key = ('@' + api_key.underscore).intern
-        api = instance_variable_get(key)
-        return api if api.present?
-
-        api = create_instance(api_key)
-        api.repo_owner = keys[:repo_owner]
-        api.repo_slug  = keys[:repo_slug]
-        instance_variable_set(key, api)
-
-        api
-      end
-
-      def create_instance(klass_name)
-        ApiFactory.create_instance(klass_name)
-      end
 
       def logger
         Tinybucket.logger

--- a/lib/tinybucket/model/commit.rb
+++ b/lib/tinybucket/model/commit.rb
@@ -39,11 +39,7 @@ module Tinybucket
       # @return [Tinybucket::Enumerator] enumerator to enumerate comments
       #   as {Tinybucket::Model::Comment} instance.
       def comments(options = {})
-        enumerator(
-          comments_api,
-          :list,
-          options
-        ) { |m| block_given? ? yield(m) : m }
+        comments_resource(options)
       end
 
       # Get the specific commit comment which associate with this commit.
@@ -52,7 +48,7 @@ module Tinybucket
       # @param options [Hash]
       # @return [Tinybucket::Model::Comment]
       def comment(comment_id, options = {})
-        comments_api.find(comment_id, options)
+        comments_resource.find(comment_id, options)
       end
 
       # Give approval on this commit.
@@ -73,12 +69,8 @@ module Tinybucket
 
       private
 
-      def comments_api
-        raise ArgumentError, MISSING_REPOSITORY_KEY unless repo_keys?
-
-        api = create_api('Comments', repo_keys)
-        api.commented_to = self
-        api
+      def comments_resource(options = {})
+        Tinybucket::Resource::Commit::Comments.new(self, options)
       end
 
       def commit_api

--- a/lib/tinybucket/model/concerns.rb
+++ b/lib/tinybucket/model/concerns.rb
@@ -5,6 +5,7 @@ module Tinybucket
 
       [
         :AcceptableAttributes,
+        :ApiCallable,
         :Enumerable,
         :RepositoryKeys,
         :Reloadable

--- a/lib/tinybucket/model/concerns/api_callable.rb
+++ b/lib/tinybucket/model/concerns/api_callable.rb
@@ -1,0 +1,19 @@
+module Tinybucket
+  module Model
+    module Concerns
+      module ApiCallable
+        protected
+
+        def create_api(name, keys = {})
+          api = ApiFactory.create_instance(name)
+          return api if keys.empty?
+
+          api.tap do |m|
+            m.repo_owner = keys[:repo_owner]
+            m.repo_slug  = keys[:repo_slug]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/model/profile.rb
+++ b/lib/tinybucket/model/profile.rb
@@ -31,50 +31,33 @@ module Tinybucket
       # Get this user's followers
       #
       # @param options [Hash]
-      # @return [Tinybucket::Enumerator] enumerator to enumerate followers
-      #   as {Tinybucket::Model::Profile} instance.
+      # @return [Tinybucket::Resource::User::Followers]
       def followers(options = {})
-        enumerator(
-          user_api,
-          :followers,
-          options
-        ) { |m| block_given? ? yield(m) : m }
+        Tinybucket::Resource::User::Followers.new(username, options)
       end
 
       # Get users which this user is following
       #
       # @param options [Hash]
-      # @return [Tinybucket::Enumerator] an enumerator to enumerate followings
-      #   as {Tinybucket::Model::Profile} instance.
+      # @return [Tinybucket::Resource::User::Following]
       def following(options = {})
-        enumerator(
-          user_api,
-          :following,
-          options
-        ) { |m| block_given? ? yield(m) : m }
+        Tinybucket::Resource::User::Following.new(username, options)
       end
 
       # Get this user's repositories
       #
       # @param options [Hash]
-      # @return [Tinybucket::Enumerator] an enumerator to enumerate repositories
-      #   as {Tinybucket::Model::Repository} instance.
+      # @return [Tinybucket::Resource::User::Repos]
       def repos(options = {})
-        enumerator(
-          user_api,
-          :repos,
-          options
-        ) { |m| block_given? ? yield(m) : m }
+        Tinybucket::Resource::User::Repos.new(username, options)
       end
 
       private
 
       def user_api
-        return @user if @user
-
-        @user = create_instance('User')
-        @user.username = username
-        @user
+        create_api('User').tap do |api|
+          api.username = username
+        end
       end
 
       def load_model

--- a/lib/tinybucket/model/pull_request.rb
+++ b/lib/tinybucket/model/pull_request.rb
@@ -55,14 +55,6 @@ module Tinybucket
         :created_on, :author, :updated_on, :merge_commit, :closed_by,
         :reviewers, :participants, :uuid, :type
 
-      # Create a new pull request.
-      #
-      # @todo to be implemented.
-      # @raise [NotImplementedError] to be implemented.
-      def create(_params)
-        raise NotImplementedError
-      end
-
       # Update this pull request.
       #
       # @todo to be implemented.
@@ -98,36 +90,26 @@ module Tinybucket
       # Get commits associated with this pull request.
       #
       # @param options [Hash]
-      # @return [Tinybucket::Enumerator] enumerator to enumerate commits
-      #   as {Tinybucket::Model::Commit} instance.
+      # @return [Tinybucket::Resource::PullRequest::Commits]
       def commits(options = {})
-        enumerator(
-          pull_request_api,
-          :commits,
-          id,
-          options
-        ) { |m| block_given? ? yield(m) : m }
+        commits_resource(options)
       end
 
       # Get comments on this pull request.
       #
       # @param options [Hash]
-      # @return [Tinybucket::Enumerator] enumerator to enumerate comments
-      #   as {Tinybucket::Model::Comment} instance.
+      # @return [Tinybucket::Resource::PullRequest::Comments]
       def comments(options = {})
-        enumerator(
-          comment_api,
-          :list,
-          options
-        ) { |m| block_given? ? yield(m) : m }
+        comments_resource(options)
       end
 
       # Get the specific comment on this pull request.
       #
+      # @param comment_id [String]
       # @param options [Hash]
       # @return [Tinybucket::Model::Comment]
       def comment(comment_id, options = {})
-        comment_api.find(comment_id, options)
+        comments_resource.find(comment_id, options)
       end
 
       # Get the diff for this pull request.
@@ -146,12 +128,20 @@ module Tinybucket
         pull_request_api.merge(id, options)
       end
 
+      # Get activities on this pull requests.
+      #
+      def activities(_options = {})
+        raise NotImplementedError
+      end
+
       private
 
-      def comment_api
-        api = create_api('Comments', repo_keys)
-        api.commented_to = self
-        api
+      def commits_resource(options = {})
+        Tinybucket::Resource::PullRequest::Commits.new(self, options)
+      end
+
+      def comments_resource(options = {})
+        Tinybucket::Resource::PullRequest::Comments.new(self, options)
       end
 
       def pull_request_api

--- a/lib/tinybucket/model/repository.rb
+++ b/lib/tinybucket/model/repository.rb
@@ -58,14 +58,6 @@ module Tinybucket
         end
       end
 
-      # Create a new repository.
-      #
-      # @todo to be implemented.
-      # @raise [NotImplementedError] to be implemented.
-      def create(_params)
-        raise NotImplementedError
-      end
-
       # Remove this repository
       #
       # @todo to be implemented.
@@ -80,14 +72,7 @@ module Tinybucket
       # @return [Tinybucket::Enumerator] an enumerator to enumerate
       #   pull requests as {Tinybucket::Model::PullRequest} instance.
       def pull_requests(options = {})
-        enumerator(
-          pull_requests_api,
-          :list,
-          options
-        ) do |m|
-          inject_repo_keys(m)
-          block_given? ? yield(m) : m
-        end
+        pull_requests_resource(options)
       end
 
       # Get the specific pull request on this repository.
@@ -95,61 +80,32 @@ module Tinybucket
       # @param pullrequest_id [String]
       # @param options [Hash]
       # @return [Tinybucket::Model::PullRequest]
-      def pull_request(pullrequest_id = nil, options = {})
-        m = if pullrequest_id.present?
-              pull_requests_api.find(pullrequest_id, options)
-            else
-              Tinybucket::Model::PullRequest.new({})
-            end
-        inject_repo_keys(m)
+      def pull_request(pullrequest_id, options = {})
+        pull_requests_resource.find(pullrequest_id, options)
       end
 
       # Get watchers on this repository.
       #
       # @param options [Hash]
-      # @return [Tinybucket::Enumerator] an enumerator to enumerate watchers
-      #   as {Tinybucket::Model::Profile} instance.
+      # @return [Tinybucket::Resource::Watchers]
       def watchers(options = {})
-        enumerator(
-          repo_api,
-          :watchers,
-          options
-        ) do |m|
-          inject_repo_keys(m)
-          block_given? ? yield(m) : m
-        end
+        watchers_resource(options)
       end
 
       # Get repository forks.
       #
       # @param options [Hash]
-      # @return [Tinybucket::Enumerator] an enumerator to enumerate forks
-      #   as {Tinybucket::Model::Repository} instance.
+      # @return [Tinybucket::Resource::Forks]
       def forks(options = {})
-        enumerator(
-          repo_api,
-          :forks,
-          options
-        ) do |m|
-          inject_repo_keys(m)
-          block_given? ? yield(m) : m
-        end
+        forks_resource(options)
       end
 
       # Get commits on this repository.
       #
       # @param options [Hash]
-      # @return [Tinybucket::Enumerator] an enumerator to enumerate commits
-      #   as {Tinybucket::Model::Commit} instance.
+      # @return [Tinybucket::Resource::Commits]
       def commits(options = {})
-        enumerator(
-          commits_api,
-          :list,
-          options
-        ) do |m|
-          inject_repo_keys(m)
-          block_given? ? yield(m) : m
-        end
+        commits_resource(options)
       end
 
       # Get the specific commit on this repository.
@@ -158,25 +114,15 @@ module Tinybucket
       # @param options [Hash]
       # @return [Tinybucket::Model::Commit]
       def commit(revision, options = {})
-        m = commits_api.find(revision, options)
-        inject_repo_keys(m)
+        commits_resource.find(revision, options)
       end
 
       # Get the branch restriction information associated with this repository.
       #
       # @param options [Hash]
-      # @return [Tinybucket::Enumerator] an enumerator to enumerate
-      #   branch restriction information as
-      #   {Tinybucket::Model::BranchRestriction} instance.
+      # @return [Tinybucket::Resource::BranchRestrictions]
       def branch_restrictions(options = {})
-        enumerator(
-          restrictions_api,
-          :list,
-          options
-        ) do |m|
-          inject_repo_keys(m)
-          block_given? ? yield(m) : m
-        end
+        branch_restrictions_resource(options)
       end
 
       # Get the specific branch restriction information on this repository.
@@ -185,8 +131,7 @@ module Tinybucket
       # @param options [Hash]
       # @return [Tinybucket::Model::BranchRestriction]
       def branch_restriction(restriction_id, options = {})
-        m = restrictions_api.find(restriction_id, options)
-        inject_repo_keys(m)
+        branch_restrictions_resource.find(restriction_id, options)
       end
 
       # Get the diff for this repository.
@@ -210,20 +155,28 @@ module Tinybucket
 
       private
 
-      def pull_requests_api
-        create_api('PullRequests', repo_keys)
+      def branch_restrictions_resource(options = {})
+        Tinybucket::Resource::BranchRestrictions.new(self, options)
+      end
+
+      def commits_resource(options = {})
+        Tinybucket::Resource::Commits.new(self, options)
+      end
+
+      def pull_requests_resource(options = {})
+        Tinybucket::Resource::PullRequests.new(self, options)
+      end
+
+      def watchers_resource(options = {})
+        Tinybucket::Resource::Watchers.new(self, options)
+      end
+
+      def forks_resource(options = {})
+        Tinybucket::Resource::Forks.new(self, options)
       end
 
       def repo_api
         create_api('Repo', repo_keys)
-      end
-
-      def commits_api
-        create_api('Commits', repo_keys)
-      end
-
-      def restrictions_api
-        create_api('BranchRestrictions', repo_keys)
       end
 
       def diff_api

--- a/lib/tinybucket/model/team.rb
+++ b/lib/tinybucket/model/team.rb
@@ -31,64 +31,39 @@ module Tinybucket
       # Get this team's members.
       #
       # @param options [Hash]
-      # @return [Tinybucket::Enumerator] an enumerator to enumerate members
-      #   as {Tinybucket::Model::Team} instance.
+      # @return [Tinybucket::Resource::Team::Members]
       def members(options = {})
-        enumerator(
-          team_api,
-          :members,
-          username,
-          options
-        ) { |m| block_given? ? yield(m) : m }
+        Tinybucket::Resource::Team::Members.new(username, options)
       end
 
       # Get this team's followers.
       #
       # @param options [Hash]
-      # @return [Tinybucket::Enumerator] an enumerator to enumerate followers
-      #   as {Tinybucket::Model::Team} instance.
+      # @return [Tinybucket::Resource::Team::Followers]
       def followers(options = {})
-        enumerator(
-          team_api,
-          :followers,
-          username,
-          options
-        ) { |m| block_given? ? yield(m) : m }
+        Tinybucket::Resource::Team::Followers.new(username, options)
       end
 
       # Get users which this team is following.
       #
       # @param options [Hash]
-      # @return [Tinybucket::Enumerator] an enumerator to enumerate followings
-      #   as {Tinybucket::Model::Team} instance.
+      # @return [Tinybucket::Resource::Team::Following]
       def following(options = {})
-        enumerator(
-          team_api,
-          :following,
-          username,
-          options
-        ) { |m| block_given? ? yield(m) : m }
+        Tinybucket::Resource::Team::Following.new(username, options)
       end
 
       # Get this team's repositories.
       #
       # @param options [Hash]
-      # @return [Tinybucket::Enumerator] an enumerator to enumerate repositories
-      #   as {Tinybucket::Model::Repository} instance.
+      # @return [Tinybucket::Resource::Team::Repos]
       def repos(options = {})
-        enumerator(
-          team_api,
-          :repos,
-          username,
-          options
-        ) { |m| block_given? ? yield(m) : m }
+        Tinybucket::Resource::Team::Repos.new(username, options)
       end
 
       private
 
       def team_api
-        return @team if @team
-        @team = create_instance('Team')
+        create_api('Team')
       end
 
       def load_model

--- a/lib/tinybucket/resource.rb
+++ b/lib/tinybucket/resource.rb
@@ -1,0 +1,70 @@
+module Tinybucket
+  module Resource
+    extend ActiveSupport::Autoload
+
+    [
+      :Base,
+      :BranchRestrictions,
+      :Commits,
+      :Forks,
+      :OwnersRepos,
+      :PublicRepos,
+      :PullRequests,
+      :Repos,
+      :Watchers
+    ].each do |klass_name|
+      autoload klass_name
+    end
+
+    module Team
+      extend ActiveSupport::Autoload
+
+      [
+        :Base,
+        :Followers,
+        :Following,
+        :Members,
+        :Repos
+      ].each do |klass_name|
+        autoload klass_name
+      end
+    end
+
+    module User
+      extend ActiveSupport::Autoload
+
+      [
+        :Base,
+        :Followers,
+        :Following,
+        :Repos
+      ].each do |klass_name|
+        autoload klass_name
+      end
+    end
+
+    module PullRequest
+      extend ActiveSupport::Autoload
+
+      [
+        :Base,
+        :Commits,
+        :Comments
+      ].each do |klass_name|
+        autoload klass_name
+      end
+    end
+
+    module Commit
+      extend ActiveSupport::Autoload
+
+      [
+        :Base,
+        :Comments,
+        :Commits
+      ].each do |klass_name|
+        autoload klass_name
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/base.rb
+++ b/lib/tinybucket/resource/base.rb
@@ -1,0 +1,29 @@
+module Tinybucket
+  module Resource
+    class Base
+      include Tinybucket::Model::Concerns::ApiCallable
+
+      protected
+
+      def method_missing(method, *args)
+        enum = enumerator
+        return super unless enum.respond_to?(method)
+
+        enum.send(method, *args) do |m|
+          block_given? ? yield(m) : m
+        end
+      end
+
+      def create_enumerator(api_client, method, *args, &block)
+        iter = Tinybucket::Iterator.new(api_client, method, *args)
+        Tinybucket::Enumerator.new(iter, block)
+      end
+
+      def inject_repo_keys(model, repo_keys)
+        return model unless model.respond_to?(:repo_keys=)
+
+        model.tap { |m| m.repo_keys = repo_keys }
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/branch_restrictions.rb
+++ b/lib/tinybucket/resource/branch_restrictions.rb
@@ -1,0 +1,44 @@
+module Tinybucket
+  module Resource
+    class BranchRestrictions < Base
+      # Constructor
+      #
+      # @param repo [Tinybucket::Model::Repository]
+      # @param options [Hash]
+      def initialize(repo, options)
+        @repo = repo
+        @args = [options]
+      end
+
+      # Create new BranchRestriction on the repository.
+      #
+      # @param _options [Hash]
+      # @return [Tinybucket::Model::BranchRestriction]
+      def create(_options)
+        raise NotImplementedError
+      end
+
+      # Find the BranchRestriction on the repository.
+      #
+      # @param _options [Hash]
+      # @return [Tinybucket::Model::BranchRestriction]
+      def find(restriction_id, options = {})
+        restrictions_api.find(restriction_id, options).tap do |m|
+          inject_repo_keys(m, @repo.repo_keys)
+        end
+      end
+
+      private
+
+      def restrictions_api
+        create_api('BranchRestrictions', @repo.repo_keys)
+      end
+
+      def enumerator
+        create_enumerator(restrictions_api, :list, *@args) do |m|
+          inject_repo_keys(m, @repo.repo_keys)
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/commit/base.rb
+++ b/lib/tinybucket/resource/commit/base.rb
@@ -1,0 +1,12 @@
+module Tinybucket
+  module Resource
+    module Commit
+      class Base < Tinybucket::Resource::Base
+        def initialize(commit, options)
+          @commit = commit
+          @args = [options]
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/commit/comments.rb
+++ b/lib/tinybucket/resource/commit/comments.rb
@@ -1,0 +1,32 @@
+module Tinybucket
+  module Resource
+    module Commit
+      class Comments < Tinybucket::Resource::Commit::Base
+        # Get the specific commit comment which associate with the commit.
+        #
+        # @param comment_id [String]
+        # @param options [Hash]
+        # @return [Tinybucket::Model::Comment]
+        def find(comment_id, options = {})
+          comments_api.find(comment_id, options).tap do |m|
+            m.repo_keys = @commit.repo_keys
+          end
+        end
+
+        private
+
+        def comments_api
+          create_api('Comments', @commit.repo_keys).tap do |api|
+            api.commented_to = @commit
+          end
+        end
+
+        def enumerator
+          create_enumerator(comments_api, :list, *@args) do |m|
+            inject_repo_keys(m, @commit.repo_keys)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/commits.rb
+++ b/lib/tinybucket/resource/commits.rb
@@ -1,0 +1,33 @@
+module Tinybucket
+  module Resource
+    class Commits < Base
+      def initialize(repo, options)
+        @repo = repo
+        @args = [options]
+      end
+
+      # Find the commit
+      #
+      # @param revision [String]
+      # @param options [Hash]
+      # @return [Tinybucket::Model::Commit]
+      def find(revision, options = {})
+        commits_api.find(revision, options).tap do |m|
+          inject_repo_keys(m, @repo.repo_keys)
+        end
+      end
+
+      private
+
+      def commits_api
+        create_api('Commits', @repo.repo_keys)
+      end
+
+      def enumerator
+        create_enumerator(commits_api, :list, *@args) do |m|
+          inject_repo_keys(m, @repo.repo_keys)
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/forks.rb
+++ b/lib/tinybucket/resource/forks.rb
@@ -1,0 +1,22 @@
+module Tinybucket
+  module Resource
+    class Forks < Base
+      def initialize(repo, options)
+        @repo = repo
+        @args = [options]
+      end
+
+      private
+
+      def repo_api
+        create_api('Repo', @repo.repo_keys)
+      end
+
+      def enumerator
+        create_enumerator(repo_api, :forks, *@args) do |m|
+          inject_repo_keys(m, @repo.repo_keys)
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/pull_request/base.rb
+++ b/lib/tinybucket/resource/pull_request/base.rb
@@ -1,0 +1,18 @@
+module Tinybucket
+  module Resource
+    module PullRequest
+      class Base < Tinybucket::Resource::Base
+        def initialize(pull_request, options)
+          @pull_request = pull_request
+          @args = [options]
+        end
+
+        protected
+
+        def pull_request_api
+          create_api('PullRequests', @pull_request.repo_keys)
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/pull_request/comments.rb
+++ b/lib/tinybucket/resource/pull_request/comments.rb
@@ -1,0 +1,30 @@
+module Tinybucket
+  module Resource
+    module PullRequest
+      class Comments < Tinybucket::Resource::PullRequest::Base
+        # Get the specific comment on the pull request.
+        #
+        # @param comment_id [String]
+        # @param options [Hash]
+        # @return [Tinybucket::Model::Comment]
+        def find(comment_id, options)
+          comment_api.find(comment_id, options)
+        end
+
+        private
+
+        def comment_api
+          create_api('Comments', @pull_request.repo_keys).tap do |api|
+            api.commented_to = @pull_request
+          end
+        end
+
+        def enumerator
+          create_enumerator(comment_api, :list, *@args) do |m|
+            inject_repo_keys(m, @pull_request.repo_keys)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/pull_request/commits.rb
+++ b/lib/tinybucket/resource/pull_request/commits.rb
@@ -1,0 +1,17 @@
+module Tinybucket
+  module Resource
+    module PullRequest
+      class Commits < Tinybucket::Resource::PullRequest::Base
+        private
+
+        def enumerator
+          params = [@pull_request.id].concat(@args)
+
+          create_enumerator(pull_request_api, :commits, *params) do |m|
+            inject_repo_keys(m, @pull_request.repo_keys)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/pull_requests.rb
+++ b/lib/tinybucket/resource/pull_requests.rb
@@ -1,0 +1,48 @@
+module Tinybucket
+  module Resource
+    class PullRequests < Base
+      def initialize(repo, options)
+        @repo = repo
+        @args = [options]
+      end
+
+      # Create a new pull request.
+      #
+      # @todo to be implemented.
+      # @raise [NotImplementedError] to be implemented.
+      def create(_options)
+        raise NotImplementedError
+      end
+
+      # Get the specific pull request on the repository.
+      #
+      # @param pullrequest_id [String]
+      # @param options [Hash]
+      # @return [Tinybucket::Model::PullRequest]
+      def find(pullrequest_id, options = {})
+        pull_requests_api.find(pullrequest_id, options).tap do |m|
+          inject_repo_keys(m, @repo.repo_keys)
+        end
+      end
+
+      # Get activities on the po
+      #
+      # TODO: To be implemented.
+      def activities(_options)
+        raise NotImplementedError
+      end
+
+      private
+
+      def pull_requests_api
+        create_api('PullRequests', @repo.repo_keys)
+      end
+
+      def enumerator
+        create_enumerator(pull_requests_api, :list, *@args) do |m|
+          inject_repo_keys(m, @repo.repo_keys)
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/repos.rb
+++ b/lib/tinybucket/resource/repos.rb
@@ -1,0 +1,38 @@
+module Tinybucket
+  module Resource
+    class Repos < Base
+      def initialize(owner, options)
+        @owner = owner
+        @args = [options]
+      end
+
+      def create(_options)
+        raise NotImplementedError
+      end
+
+      def find(_options)
+        raise NotImplementedError
+      end
+
+      private
+
+      def user_api
+        create_api('User').tap do |api|
+          api.username = @owner
+        end
+      end
+
+      def repos_api
+        create_api('Repos')
+      end
+
+      def enumerator
+        if @owner
+          create_enumerator(user_api, :repos, *@args)
+        else
+          create_enumerator(repos_api, :list, *@args)
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/team/base.rb
+++ b/lib/tinybucket/resource/team/base.rb
@@ -1,0 +1,22 @@
+module Tinybucket
+  module Resource
+    module Team
+      class Base < Tinybucket::Resource::Base
+        def initialize(team_name, options)
+          @team_name = team_name
+          @args = [options]
+        end
+
+        protected
+
+        def team_api
+          create_api('Team')
+        end
+
+        def create_team_enumerator(method)
+          create_enumerator(team_api, method, @team_name, *@args)
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/team/followers.rb
+++ b/lib/tinybucket/resource/team/followers.rb
@@ -1,0 +1,13 @@
+module Tinybucket
+  module Resource
+    module Team
+      class Followers < Tinybucket::Resource::Team::Base
+        private
+
+        def enumerator
+          create_team_enumerator(:followers)
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/team/following.rb
+++ b/lib/tinybucket/resource/team/following.rb
@@ -1,0 +1,13 @@
+module Tinybucket
+  module Resource
+    module Team
+      class Following < Tinybucket::Resource::Team::Base
+        private
+
+        def enumerator
+          create_team_enumerator(:following)
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/team/members.rb
+++ b/lib/tinybucket/resource/team/members.rb
@@ -1,0 +1,13 @@
+module Tinybucket
+  module Resource
+    module Team
+      class Members < Tinybucket::Resource::Team::Base
+        private
+
+        def enumerator
+          create_team_enumerator(:members)
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/team/repos.rb
+++ b/lib/tinybucket/resource/team/repos.rb
@@ -1,0 +1,13 @@
+module Tinybucket
+  module Resource
+    module Team
+      class Repos < Tinybucket::Resource::Team::Base
+        private
+
+        def enumerator
+          create_team_enumerator(:repos)
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/user/base.rb
+++ b/lib/tinybucket/resource/user/base.rb
@@ -1,0 +1,24 @@
+module Tinybucket
+  module Resource
+    module User
+      class Base < Tinybucket::Resource::Base
+        def initialize(user_name, options)
+          @user_name = user_name
+          @args = [options]
+        end
+
+        protected
+
+        def user_api
+          create_api('User').tap do |api|
+            api.username = @user_name
+          end
+        end
+
+        def create_user_enumerator(method)
+          create_enumerator(user_api, method, *@args)
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/user/followers.rb
+++ b/lib/tinybucket/resource/user/followers.rb
@@ -1,0 +1,13 @@
+module Tinybucket
+  module Resource
+    module User
+      class Followers < Tinybucket::Resource::User::Base
+        private
+
+        def enumerator
+          create_user_enumerator(:followers)
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/user/following.rb
+++ b/lib/tinybucket/resource/user/following.rb
@@ -1,0 +1,13 @@
+module Tinybucket
+  module Resource
+    module User
+      class Following < Tinybucket::Resource::User::Base
+        private
+
+        def enumerator
+          create_user_enumerator(:following)
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/user/repos.rb
+++ b/lib/tinybucket/resource/user/repos.rb
@@ -1,0 +1,13 @@
+module Tinybucket
+  module Resource
+    module User
+      class Repos < Tinybucket::Resource::User::Base
+        private
+
+        def enumerator
+          create_user_enumerator(:repos)
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource/watchers.rb
+++ b/lib/tinybucket/resource/watchers.rb
@@ -1,0 +1,22 @@
+module Tinybucket
+  module Resource
+    class Watchers < Base
+      def initialize(repo, options)
+        @repo = repo
+        @args = [options]
+      end
+
+      private
+
+      def repo_api
+        create_api('Repo', @repo.repo_keys)
+      end
+
+      def enumerator
+        create_enumerator(repo_api, :watchers, *@args) do |m|
+          inject_repo_keys(m, @repo.repo_keys)
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/repositories/test_owner/get.json
+++ b/spec/fixtures/repositories/test_owner/get.json
@@ -74,5 +74,5 @@
     }
   ],
   "page": 1,
-  "next": "https://api.bitbucket.org/2.0/repositories?pagelen=1&after=2013-09-26T23%3A01%3A01.638828%2B00%3A00&page=2"
+  "next": "https://api.bitbucket.org/2.0/repositories/test_owner?pagelen=1&after=2013-09-26T23%3A01%3A01.638828%2B00%3A00&page=2"
 }

--- a/spec/fixtures/repositories/test_owner/test_repo/pullrequests/1/comments/get.json
+++ b/spec/fixtures/repositories/test_owner/test_repo/pullrequests/1/comments/get.json
@@ -1,6 +1,6 @@
 {
     "pagelen": 1,
-    "next": "https://api.bitbucket.org/2.0/repositories/bitbucket/bitbucket/pullrequests/3767/comments?pagelen=1&page=2",
+    "next": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/pullrequests/1/comments?pagelen=1&page=2",
     "values": [{
         "parent": {
             "id": 25334,

--- a/spec/fixtures/repositories/test_owner/test_repo/pullrequests/1/commits/get.json
+++ b/spec/fixtures/repositories/test_owner/test_repo/pullrequests/1/commits/get.json
@@ -1,6 +1,6 @@
 {
     "pagelen": 1,
-    "next": "https://api.bitbucket.org/2.0/repositories/bitbucket/bitbucket/pullrequests/3764/commits?pagelen=1&page=2",
+    "next": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/pullrequests/1/commits?pagelen=1&page=2",
     "values": [{
         "hash": "ad758aeba36fa4b9d258ac1667f55cfb811e6df3",
         "links": {

--- a/spec/fixtures/repositories/test_owner/test_repo/pullrequests/get.json
+++ b/spec/fixtures/repositories/test_owner/test_repo/pullrequests/get.json
@@ -1,6 +1,6 @@
 {
     "pagelen": 1,
-    "next": "https://api.bitbucket.org/2.0/repositories/bitbucket/bitbucket/pullrequests?pagelen=1&page=2",
+    "next": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/pullrequests?pagelen=1&page=2",
     "values": [{
         "description": "![img](https://cloudup.com/c7ZJtChLw9J+)\r\n\r\n## Removing:\r\n\r\n* Notifications\r\n* Email\r\n* Change password\r\n* Sessions\r\n\r\n## Renaming: \r\n\r\n* Change username\r\n* Delete account (rename to delete team)\r\n\r\n",
         "links": {

--- a/spec/fixtures/repositories/test_owner/test_repo/watchers/get.json
+++ b/spec/fixtures/repositories/test_owner/test_repo/watchers/get.json
@@ -1,6 +1,6 @@
 {
   "pagelen": 2,
-  "next": "https://api.bitbucket.org/2.0/repositories/tutorials/tutorials.bitbucket.org/watchers?pagelen=2&page=2",
+  "next": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/watchers?pagelen=2&page=2",
   "values": [
     {
       "username": "tutorials",

--- a/spec/lib/tinybucket/client_spec.rb
+++ b/spec/lib/tinybucket/client_spec.rb
@@ -16,12 +16,14 @@ RSpec.describe Tinybucket::Client do
 
       context 'without options' do
         subject { client.repos }
-        it { expect(subject).to be_instance_of(Tinybucket::Enumerator) }
+        it { expect(subject).to be_instance_of(Tinybucket::Resource::Repos) }
+        it { expect(subject.instance_variable_get(:@owner)).to be_nil }
       end
       context 'with options' do
         subject { client.repos(options) }
         let(:options) { {} }
-        it { expect(subject).to be_instance_of(Tinybucket::Enumerator) }
+        it { expect(subject).to be_instance_of(Tinybucket::Resource::Repos) }
+        it { expect(subject.instance_variable_get(:@owner)).to be_nil }
       end
     end
 
@@ -32,13 +34,15 @@ RSpec.describe Tinybucket::Client do
       context 'without options' do
         let(:request_path) { "/repositories/#{owner}" }
         subject { client.repos(owner) }
-        it { expect(subject).to be_instance_of(Tinybucket::Enumerator) }
+        it { expect(subject).to be_instance_of(Tinybucket::Resource::Repos) }
+        it { expect(subject.instance_variable_get(:@owner)).to eq(owner) }
       end
       context 'with options' do
         let(:request_path) { "/repositories/#{owner}" }
         subject { client.repos(owner, options) }
         let(:options) { {} }
-        it { expect(subject).to be_instance_of(Tinybucket::Enumerator) }
+        it { expect(subject).to be_instance_of(Tinybucket::Resource::Repos) }
+        it { expect(subject.instance_variable_get(:@owner)).to eq(owner) }
       end
     end
 

--- a/spec/lib/tinybucket/model/commit_spec.rb
+++ b/spec/lib/tinybucket/model/commit_spec.rb
@@ -51,7 +51,9 @@ RSpec.describe Tinybucket::Model::Commit do
       "/repositories/#{owner}/#{slug}/commit/1/comments"
     end
     subject { model.comments }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
+    it 'return resource' do
+      expect(subject).to be_an_instance_of(Tinybucket::Resource::Commit::Comments)
+    end
   end
 
   describe '#comment' do

--- a/spec/lib/tinybucket/model/profile_spec.rb
+++ b/spec/lib/tinybucket/model/profile_spec.rb
@@ -35,18 +35,18 @@ RSpec.describe Tinybucket::Model::Profile do
   describe 'followers' do
     let(:request_path) { "/users/#{username}/followers" }
     subject { model.followers() }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Resource::User::Followers) }
   end
 
   describe 'following' do
     let(:request_path) { "/users/#{username}/following" }
     subject { model.following }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Resource::User::Following) }
   end
 
   describe 'repos' do
     let(:request_path) { "/repositories/#{username}" }
     subject { model.repos }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Resource::User::Repos) }
   end
 end

--- a/spec/lib/tinybucket/model/pull_request_spec.rb
+++ b/spec/lib/tinybucket/model/pull_request_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Tinybucket::Model::PullRequest do
 
     subject { model.commits() }
 
-    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Resource::PullRequest::Commits) }
   end
 
   describe 'comments' do
@@ -103,19 +103,7 @@ RSpec.describe Tinybucket::Model::PullRequest do
     end
 
     subject { model.comments }
-
-    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
-    it 'return comments which associate with this pull request' do
-      # extract iterator from enumerator.
-      iterator = subject.instance_variable_get(:@iterator)
-      # extract values from iterator.
-      values = iterator.instance_variable_get(:@values)
-
-      values.each do |comment|
-        expect(comment).to be_an_instance_of(Tinybucket::Model::Comment)
-        expect(comment.commented_to).to eq(model)
-      end
-    end
+    it { expect(subject).to be_an_instance_of(Tinybucket::Resource::PullRequest::Comments) }
   end
 
   describe 'comment' do
@@ -138,8 +126,8 @@ RSpec.describe Tinybucket::Model::PullRequest do
       "/repositories/#{owner}/#{slug}/pullrequests/1/diff"
     end
     it { expect(subject).to be_instance_of(String) }
-
   end
+
   describe 'merge' do
     let(:request_method) { :post }
     let(:request_path) do

--- a/spec/lib/tinybucket/model/repository_spec.rb
+++ b/spec/lib/tinybucket/model/repository_spec.rb
@@ -52,47 +52,38 @@ RSpec.describe Tinybucket::Model::Repository do
 
     subject { model.pull_requests() }
 
-    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Resource::PullRequests) }
   end
 
   describe '#pull_request' do
     let(:prid) { 1 }
 
-    describe 'with pull_request_id' do
-      subject { model.pull_request(prid) }
-      let(:request_path) do
-        "/repositories/#{owner}/#{slug}/pullrequests/#{prid}"
-      end
-      it 'return the specific pull_request model' do
-        expect(subject).to be_an_instance_of(Tinybucket::Model::PullRequest)
-        expect(subject.id).to eq(prid)
-      end
+    subject { model.pull_request(prid) }
+    let(:request_path) do
+      "/repositories/#{owner}/#{slug}/pullrequests/#{prid}"
     end
-    describe 'without pull_request_id' do
-      subject { model.pull_request }
-      it 'return new pull_request model' do
-        expect(subject).to be_an_instance_of(Tinybucket::Model::PullRequest)
-        expect(subject.id).to be_nil
-      end
+    it 'return the specific pull_request model' do
+      expect(subject).to be_an_instance_of(Tinybucket::Model::PullRequest)
+      expect(subject.id).to eq(prid)
     end
   end
 
   describe '#watchers' do
     let(:request_path) { "/repositories/#{owner}/#{slug}/watchers" }
     subject { model.watchers }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Resource::Watchers) }
   end
 
   describe '#forks' do
     let(:request_path) { "/repositories/#{owner}/#{slug}/forks" }
     subject { model.forks }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Resource::Forks) }
   end
 
   describe '#commits' do
     let(:request_path) { "/repositories/#{owner}/#{slug}/commits" }
     subject { model.commits }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Resource::Commits) }
   end
 
   describe '#commit' do
@@ -105,7 +96,10 @@ RSpec.describe Tinybucket::Model::Repository do
   describe '#branch_restrictions' do
     let(:request_path) { "/repositories/#{owner}/#{slug}/branch-restrictions" }
     subject { model.branch_restrictions }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
+    it 'return resource model' do
+      expect(subject).to be_an_instance_of(
+        Tinybucket::Resource::BranchRestrictions)
+    end
   end
 
   describe '#branch_restriction' do

--- a/spec/lib/tinybucket/model/team_spec.rb
+++ b/spec/lib/tinybucket/model/team_spec.rb
@@ -35,24 +35,36 @@ RSpec.describe Tinybucket::Model::Team do
   describe '#members' do
     let(:request_path) { "/teams/#{teamname}/members" }
     subject { model.members }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
+    it 'return resource' do
+      expect(subject).to be_an_instance_of(
+        Tinybucket::Resource::Team::Members)
+    end
   end
 
   describe '#followers' do
     let(:request_path) { "/teams/#{teamname}/followers" }
     subject { model.followers() }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
+    it 'return resource' do
+      expect(subject).to be_an_instance_of(
+        Tinybucket::Resource::Team::Followers)
+    end
   end
 
   describe '#following' do
     let(:request_path) { "/teams/#{teamname}/following" }
     subject { model.following }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
+    it 'return resource' do
+      expect(subject).to be_an_instance_of(
+        Tinybucket::Resource::Team::Following)
+    end
   end
 
   describe '#repos' do
     let(:request_path) { "/teams/#{teamname}/repositories" }
     subject { model.repos }
-    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
+    it 'return resource' do
+      expect(subject).to be_an_instance_of(
+        Tinybucket::Resource::Team::Repos)
+    end
   end
 end

--- a/spec/lib/tinybucket/resource/branch_restrictions_spec.rb
+++ b/spec/lib/tinybucket/resource/branch_restrictions_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Resource::BranchRestrictions do
+  include ApiResponseMacros
+
+  let(:owner) { 'test_owner' }
+  let(:slug) { 'test_repo' }
+  let(:repo) do
+    Tinybucket::Model::Repository.new({}).tap do |m|
+      m.repo_owner = owner
+      m.repo_slug  = slug
+    end
+  end
+
+  let(:options) { {} }
+  let(:resource) { Tinybucket::Resource::BranchRestrictions.new(repo, options) }
+
+  describe 'constructor' do
+    subject { resource }
+    it 'create new instance' do
+      expect(subject).to be_an_instance_of(
+        Tinybucket::Resource::BranchRestrictions)
+    end
+  end
+
+  describe '#create' do
+    subject { resource.create({}) }
+    it { expect { subject.create }.to raise_error(NotImplementedError) }
+  end
+
+  describe '#find' do
+    let(:restriction_id) { '1' }
+    let(:request_path) do
+      "/repositories/#{owner}/#{slug}/branch-restrictions/#{restriction_id}"
+    end
+    subject { resource.find(restriction_id, {}) }
+    before { stub_apiresponse(:get, request_path, {}) }
+    it 'return model' do
+      expect(subject).to be_an_instance_of(Tinybucket::Model::BranchRestriction)
+    end
+  end
+
+  describe 'Enumerable Methods' do
+    let(:request_path) { "/repositories/#{owner}/#{slug}/branch-restrictions" }
+    before { stub_enum_response(:get, request_path) }
+
+    describe '#take(1)' do
+      subject { resource.take(1) }
+      it { expect(subject).to be_an_instance_of(Array) }
+    end
+
+    describe '#each' do
+      it 'iterate models' do
+        resource.each do |m|
+          expect(m).to be_an_instance_of(Tinybucket::Model::BranchRestriction)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/tinybucket/resource/commit/comments_spec.rb
+++ b/spec/lib/tinybucket/resource/commit/comments_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Resource::Commit::Comments do
+  include ApiResponseMacros
+
+  let(:owner) { 'test_owner' }
+  let(:slug) { 'test_repo' }
+  let(:revision) { '1' }
+  let(:commit) do
+    Tinybucket::Model::Commit.new({}).tap do |m|
+      m.hash = revision
+      m.repo_owner = owner
+      m.repo_slug = slug
+    end
+  end
+
+  let(:options) { {} }
+  let(:resource) { Tinybucket::Resource::Commit::Comments.new(commit, options) }
+
+  describe '#find' do
+    let(:comment_id) { '1' }
+    let(:request_path) do
+      "/repositories/#{owner}/#{slug}/commit/#{revision}/comments/#{comment_id}"
+    end
+    subject { resource.find(comment_id) }
+    before { stub_apiresponse(:get, request_path) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Model::Comment) }
+  end
+
+  describe 'Enumerable Methods' do
+    let(:request_path) do
+      "/repositories/#{owner}/#{slug}/commit/#{revision}/comments"
+    end
+    before { stub_enum_response(:get, request_path) }
+
+    describe '#take(1)' do
+      subject { resource.take(1) }
+      it { expect(subject).to be_an_instance_of(Array) }
+    end
+
+    describe '#each' do
+      it 'iterate models' do
+        resource.each do |m|
+          expect(m).to be_an_instance_of(Tinybucket::Model::Comment)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/tinybucket/resource/commits_spec.rb
+++ b/spec/lib/tinybucket/resource/commits_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Resource::Commits do
+  include ApiResponseMacros
+
+  let(:owner) { 'test_owner' }
+  let(:slug) { 'test_repo' }
+  let(:repo) do
+    Tinybucket::Model::Repository.new({}).tap do |m|
+      m.repo_owner = owner
+      m.repo_slug  = slug
+    end
+  end
+
+  let(:options) { {} }
+  let(:resource) { Tinybucket::Resource::Commits.new(repo, options) }
+
+  describe '#find' do
+    let(:revision) { '1' }
+    let(:request_path) { "/repositories/#{owner}/#{slug}/commit/#{revision}" }
+    before { stub_apiresponse(:get, request_path) }
+    subject { resource.find(revision) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Model::Commit) }
+  end
+
+  describe 'Enumerable Methods' do
+    let(:request_path) { "/repositories/#{owner}/#{slug}/commits" }
+    before { stub_enum_response(:get, request_path) }
+
+    describe '#take(1)' do
+      subject { resource.take(1) }
+      it { expect(subject).to be_an_instance_of(Array) }
+    end
+
+    describe '#each' do
+      it 'iterate models' do
+        resource.each do |m|
+          expect(m).to be_an_instance_of(Tinybucket::Model::Commit)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/tinybucket/resource/forks_spec.rb
+++ b/spec/lib/tinybucket/resource/forks_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Resource::Forks do
+  include ApiResponseMacros
+
+  let(:owner) { 'test_owner' }
+  let(:slug) { 'test_repo' }
+
+  let(:options) { {} }
+  let(:repo) do
+    Tinybucket::Model::Repository.new({}).tap do |m|
+      m.repo_owner = owner
+      m.repo_slug  = slug
+    end
+  end
+
+  let(:resource) { Tinybucket::Resource::Forks.new(repo, options) }
+
+  describe 'Enumerable Methods' do
+    let(:request_path) { "/repositories/#{owner}/#{slug}/forks" }
+    before { stub_enum_response(:get, request_path) }
+
+    describe '#take(1)' do
+      subject { resource.take(1) }
+      it { expect(subject).to be_an_instance_of(Array) }
+    end
+
+    describe '#each' do
+      it 'iterate models' do
+        resource.each do |m|
+          expect(m).to be_an_instance_of(Tinybucket::Model::Repository)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/tinybucket/resource/pull_request/comments_spec.rb
+++ b/spec/lib/tinybucket/resource/pull_request/comments_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Resource::PullRequest::Comments do
+  include ApiResponseMacros
+
+  let(:owner) { 'test_owner' }
+  let(:slug) { 'test_repo' }
+  let(:pullrequest_id) { '1' }
+  let(:pull_request) do
+    Tinybucket::Model::PullRequest.new({}).tap do |m|
+      m.id = pullrequest_id
+      m.repo_owner = owner
+      m.repo_slug = slug
+    end
+  end
+
+  let(:options) { {} }
+  let(:resource) do
+    Tinybucket::Resource::PullRequest::Comments.new(pull_request, options)
+  end
+
+  describe 'Enumerable Methods' do
+    let(:request_path) do
+      "/repositories/#{owner}/#{slug}/pullrequests/#{pullrequest_id}/comments"
+    end
+    before { stub_enum_response(:get, request_path) }
+
+    describe '#take(1)' do
+      subject { resource.take(1) }
+      it { expect(subject).to be_an_instance_of(Array) }
+    end
+
+    describe '#each' do
+      it 'iterate models' do
+        resource.each do |m|
+          expect(m).to be_an_instance_of(Tinybucket::Model::Comment)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/tinybucket/resource/pull_request/commits_spec.rb
+++ b/spec/lib/tinybucket/resource/pull_request/commits_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Resource::PullRequest::Commits do
+  include ApiResponseMacros
+
+  let(:owner) { 'test_owner' }
+  let(:slug) { 'test_repo' }
+  let(:pullrequest_id) { '1' }
+  let(:pull_request) do
+    Tinybucket::Model::PullRequest.new({}).tap do |m|
+      m.id = pullrequest_id
+      m.repo_owner = owner
+      m.repo_slug = slug
+    end
+  end
+
+  let(:options) { {} }
+  let(:resource) do
+    Tinybucket::Resource::PullRequest::Commits.new(pull_request, options)
+  end
+
+  describe 'Enumerable Methods' do
+    let(:request_path) do
+      "/repositories/#{owner}/#{slug}/pullrequests/#{pullrequest_id}/commits"
+    end
+    before { stub_enum_response(:get, request_path) }
+
+    describe '#take(1)' do
+      subject { resource.take(1) }
+      it { expect(subject).to be_an_instance_of(Array) }
+    end
+
+    describe '#each' do
+      it 'iterate models' do
+        resource.each do |m|
+          expect(m).to be_an_instance_of(Tinybucket::Model::Commit)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/tinybucket/resource/pull_requests_spec.rb
+++ b/spec/lib/tinybucket/resource/pull_requests_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Resource::PullRequests do
+  include ApiResponseMacros
+
+  let(:owner) { 'test_owner' }
+  let(:slug) { 'test_repo' }
+  let(:repo) do
+    Tinybucket::Model::Repository.new({}).tap do |m|
+      m.repo_owner = owner
+      m.repo_slug  = slug
+    end
+  end
+
+  let(:options) { {} }
+  let(:resource) { Tinybucket::Resource::PullRequests.new(repo, options) }
+
+  describe '#create' do
+    let(:params) { {} }
+    subject { resource.create(params) }
+    it { expect { subject }.to raise_error(NotImplementedError) }
+  end
+
+  describe '#find' do
+    let(:pullrequest_id) { '1' }
+    let(:request_path) do
+      "/repositories/#{owner}/#{slug}/pullrequests/#{pullrequest_id}"
+    end
+    before { stub_apiresponse(:get, request_path) }
+    subject { resource.find(pullrequest_id) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Model::PullRequest) }
+  end
+
+  describe '#activities' do
+    let(:params) { {} }
+    subject { resource.activities(params) }
+    it { expect { subject }.to raise_error(NotImplementedError) }
+  end
+
+  describe 'Enumerable Methods' do
+    let(:request_path) do
+      "/repositories/#{owner}/#{slug}/pullrequests"
+    end
+    before { stub_enum_response(:get, request_path) }
+
+    describe '#take(1)' do
+      subject { resource.take(1) }
+      it { expect(subject).to be_an_instance_of(Array) }
+    end
+
+    describe '#each' do
+      it 'iterate models' do
+        resource.each do |m|
+          expect(m).to be_an_instance_of(Tinybucket::Model::PullRequest)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/tinybucket/resource/repos_spec.rb
+++ b/spec/lib/tinybucket/resource/repos_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Resource::Repos do
+  include ApiResponseMacros
+
+  let(:options) { {} }
+  let(:resource) { Tinybucket::Resource::Repos.new(owner, options) }
+
+  describe 'Public Repos Resource' do
+    let(:owner) { nil }
+
+    describe '#create' do
+      let(:params) { {} }
+      subject { resource.create(params) }
+      it { expect { subject }.to raise_error(NotImplementedError) }
+    end
+
+    describe '#find' do
+      let(:params) { {} }
+      subject { resource.find(params) }
+      it { expect { subject }.to raise_error(NotImplementedError) }
+    end
+
+    describe 'Enumerable Methods' do
+      let(:request_path) { '/repositories' }
+      before { stub_enum_response(:get, request_path) }
+
+      describe '#take(1)' do
+        subject { resource.take(1) }
+        it { expect(subject).to be_an_instance_of(Array) }
+      end
+
+      describe '#each' do
+        it 'iterate models' do
+          resource.each do |m|
+            expect(m).to be_an_instance_of(Tinybucket::Model::Repository)
+          end
+        end
+      end
+    end
+  end
+
+  describe 'Owner\'s Repos Resource' do
+    let(:owner) { 'test_owner' }
+
+    describe '#create' do
+      let(:params) { {} }
+      subject { resource.create(params) }
+      it { expect { subject }.to raise_error(NotImplementedError) }
+    end
+
+    describe '#find' do
+      let(:params) { {} }
+      subject { resource.find(params) }
+      it { expect { subject }.to raise_error(NotImplementedError) }
+    end
+
+    describe 'Enumerable Methods' do
+      let(:request_path) { "/repositories/#{owner}" }
+      before { stub_enum_response(:get, request_path) }
+
+      describe '#take(1)' do
+        subject { resource.take(1) }
+        it { expect(subject).to be_an_instance_of(Array) }
+      end
+
+      describe '#each' do
+        it 'iterate models' do
+          resource.each do |m|
+            expect(m).to be_an_instance_of(Tinybucket::Model::Repository)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/tinybucket/resource/team/followers_spec.rb
+++ b/spec/lib/tinybucket/resource/team/followers_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Resource::Team::Followers do
+  include ApiResponseMacros
+
+  let(:team) { 'test_team' }
+  let(:options) { {} }
+  let(:resource) { Tinybucket::Resource::Team::Followers.new(team, options) }
+
+  describe 'Enumerable Methods' do
+    let(:request_path) { "/teams/#{team}/followers" }
+    before { stub_enum_response(:get, request_path) }
+
+    describe '#take(1)' do
+      subject { resource.take(1) }
+      it { expect(subject).to be_an_instance_of(Array) }
+    end
+
+    describe '#each' do
+      it 'iterate models' do
+        resource.each do |m|
+          expect(m).to be_an_instance_of(Tinybucket::Model::Team)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/tinybucket/resource/team/following_spec.rb
+++ b/spec/lib/tinybucket/resource/team/following_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Resource::Team::Following do
+  include ApiResponseMacros
+
+  let(:team) { 'test_team' }
+  let(:options) { {} }
+  let(:resource) { Tinybucket::Resource::Team::Following.new(team, options) }
+
+  describe 'Enumerable Methods' do
+    let(:request_path) { "/teams/#{team}/following" }
+    before { stub_enum_response(:get, request_path) }
+
+    describe '#take(1)' do
+      subject { resource.take(1) }
+      it { expect(subject).to be_an_instance_of(Array) }
+    end
+
+    describe '#each' do
+      it 'iterate models' do
+        resource.each do |m|
+          expect(m).to be_an_instance_of(Tinybucket::Model::Team)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/tinybucket/resource/team/members_spec.rb
+++ b/spec/lib/tinybucket/resource/team/members_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Resource::Team::Members do
+  include ApiResponseMacros
+
+  let(:team) { 'test_team' }
+  let(:options) { {} }
+  let(:resource) { Tinybucket::Resource::Team::Members.new(team, options) }
+
+  describe 'Enumerable Methods' do
+    let(:request_path) { "/teams/#{team}/members" }
+    before { stub_enum_response(:get, request_path) }
+
+    describe '#take(1)' do
+      subject { resource.take(1) }
+      it { expect(subject).to be_an_instance_of(Array) }
+    end
+
+    describe '#each' do
+      it 'iterate models' do
+        resource.each do |m|
+          expect(m).to be_an_instance_of(Tinybucket::Model::Team)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/tinybucket/resource/team/repos_spec.rb
+++ b/spec/lib/tinybucket/resource/team/repos_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Resource::User::Repos do
+  include ApiResponseMacros
+
+  let(:team) { 'test_team' }
+  let(:options) { {} }
+  let(:resource) { Tinybucket::Resource::Team::Repos.new(team, options) }
+
+  describe 'Enumerable Methods' do
+    let(:request_path) { "/teams/#{team}/repositories" }
+    before { stub_enum_response(:get, request_path) }
+
+    describe '#take(1)' do
+      subject { resource.take(1) }
+      it { expect(subject).to be_an_instance_of(Array) }
+    end
+
+    describe '#each' do
+      it 'iterate models' do
+        resource.each do |m|
+          expect(m).to be_an_instance_of(Tinybucket::Model::Repository)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/tinybucket/resource/user/followers_spec.rb
+++ b/spec/lib/tinybucket/resource/user/followers_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Resource::User::Followers do
+  include ApiResponseMacros
+
+  let(:owner) { 'test_owner' }
+  let(:options) { {} }
+  let(:resource) { Tinybucket::Resource::User::Followers.new(owner, options) }
+
+  describe 'Enumerable Methods' do
+    let(:request_path) { "/users/#{owner}/followers" }
+    before { stub_enum_response(:get, request_path) }
+
+    describe '#take(1)' do
+      subject { resource.take(1) }
+      it { expect(subject).to be_an_instance_of(Array) }
+    end
+
+    describe '#each' do
+      it 'iterate models' do
+        resource.each do |m|
+          expect(m).to be_an_instance_of(Tinybucket::Model::Profile)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/tinybucket/resource/user/following_spec.rb
+++ b/spec/lib/tinybucket/resource/user/following_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Resource::User::Following do
+  include ApiResponseMacros
+
+  let(:owner) { 'test_owner' }
+  let(:options) { {} }
+  let(:resource) { Tinybucket::Resource::User::Following.new(owner, options) }
+
+  describe 'Enumerable Methods' do
+    let(:request_path) { "/users/#{owner}/following" }
+    before { stub_enum_response(:get, request_path) }
+
+    describe '#take(1)' do
+      subject { resource.take(1) }
+      it { expect(subject).to be_an_instance_of(Array) }
+    end
+
+    describe '#each' do
+      it 'iterate models' do
+        resource.each do |m|
+          expect(m).to be_an_instance_of(Tinybucket::Model::Profile)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/tinybucket/resource/user/repos_spec.rb
+++ b/spec/lib/tinybucket/resource/user/repos_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Resource::User::Repos do
+  include ApiResponseMacros
+
+  let(:owner) { 'test_owner' }
+  let(:options) { {} }
+  let(:resource) { Tinybucket::Resource::User::Repos.new(owner, options) }
+
+  describe 'Enumerable Methods' do
+    let(:request_path) { "/repositories/#{owner}" }
+    before { stub_enum_response(:get, request_path) }
+
+    describe '#take(1)' do
+      subject { resource.take(1) }
+      it { expect(subject).to be_an_instance_of(Array) }
+    end
+
+    describe '#each' do
+      it 'iterate models' do
+        resource.each do |m|
+          expect(m).to be_an_instance_of(Tinybucket::Model::Repository)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/tinybucket/resource/watchers_spec.rb
+++ b/spec/lib/tinybucket/resource/watchers_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Resource::Watchers do
+  include ApiResponseMacros
+
+  let(:owner) { 'test_owner' }
+  let(:slug) { 'test_repo' }
+  let(:repo) do
+    Tinybucket::Model::Repository.new({}).tap do |m|
+      m.repo_owner = owner
+      m.repo_slug  = slug
+    end
+  end
+
+  let(:options) { {} }
+  let(:resource) { Tinybucket::Resource::Watchers.new(repo, options) }
+
+  describe 'Enumerable Methods' do
+    let(:params) { {} }
+    let(:request_path) do
+      "/repositories/#{owner}/#{slug}/watchers"
+    end
+    before { stub_enum_response(:get, request_path) }
+
+    describe '#take(1)' do
+      subject { resource.take(1) }
+      it { expect(subject).to be_an_instance_of(Array) }
+    end
+
+    describe '#each' do
+      it 'iterate models' do
+        resource.each do |m|
+          expect(m).to be_an_instance_of(Tinybucket::Model::Profile)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces `Resource model` to describe the resource collection.

`Resource Model` has two responsibility.

- operate to the resource collection. (like, create, find, ...)
- delegate enumerable methods to the enumerator.

This feature makes collection APIs in Tinybucket gem more usable, I think.