### PR TITLE
update endpoint url.

### DIFF
--- a/lib/tinybucket/connection.rb
+++ b/lib/tinybucket/connection.rb
@@ -25,7 +25,7 @@ module Tinybucket
           USER_AGENT: 'test client' # TODO: fix this !
         },
         ssl: { verify: false },
-        url: 'https://bitbucket.org/api/2.0'.freeze
+        url: 'https://api.bitbucket.org/2.0'.freeze
       }
     end
 

--- a/spec/fixtures/repositories/test_owner/test_repo/pullrequests/1/comments/get.json
+++ b/spec/fixtures/repositories/test_owner/test_repo/pullrequests/1/comments/get.json
@@ -1,6 +1,6 @@
 {
     "pagelen": 1,
-    "next": "https://bitbucket.org/api/2.0/repositories/bitbucket/bitbucket/pullrequests/3767/comments?pagelen=1&page=2",
+    "next": "https://api.bitbucket.org/2.0/repositories/bitbucket/bitbucket/pullrequests/3767/comments?pagelen=1&page=2",
     "values": [{
         "parent": {
             "id": 25334,

--- a/spec/fixtures/repositories/test_owner/test_repo/pullrequests/1/commits/get.json
+++ b/spec/fixtures/repositories/test_owner/test_repo/pullrequests/1/commits/get.json
@@ -1,6 +1,6 @@
 {
     "pagelen": 1,
-    "next": "https://bitbucket.org/api/2.0/repositories/bitbucket/bitbucket/pullrequests/3764/commits?pagelen=1&page=2",
+    "next": "https://api.bitbucket.org/2.0/repositories/bitbucket/bitbucket/pullrequests/3764/commits?pagelen=1&page=2",
     "values": [{
         "hash": "ad758aeba36fa4b9d258ac1667f55cfb811e6df3",
         "links": {

--- a/spec/fixtures/repositories/test_owner/test_repo/watchers/get.json
+++ b/spec/fixtures/repositories/test_owner/test_repo/watchers/get.json
@@ -1,6 +1,6 @@
 {
   "pagelen": 2,
-  "next": "https://bitbucket.org/api/2.0/repositories/tutorials/tutorials.bitbucket.org/watchers?pagelen=2&page=2",
+  "next": "https://api.bitbucket.org/2.0/repositories/tutorials/tutorials.bitbucket.org/watchers?pagelen=2&page=2",
   "values": [
     {
       "username": "tutorials",

--- a/spec/support/api_response_macros.rb
+++ b/spec/support/api_response_macros.rb
@@ -8,7 +8,7 @@ module ApiResponseMacros
       else                    'json'
       end
 
-    stub_request(method, 'https://bitbucket.org/api/2.0' + path)
+    stub_request(method, 'https://api.bitbucket.org/2.0' + path)
       .to_return(
         status: (options[:status_code] || 200),
         body: (options[:message] || fixture_json(method, path, ext)),


### PR DESCRIPTION
[This document](https://confluence.atlassian.com/bitbucket/use-the-bitbucket-cloud-rest-apis-222724129.html#UsetheBitbucketCloudRESTAPIs-URIStructureandMethods) describe that `All Bitbucket Cloud requests start with the https://api.bitbucket.org/2.0 prefix (for the 2.0 API)`.

So this gem must use `https://api.bitbucket.org/2.0` as endpoint.

