### PR TITLE
make cacheable by faraday-http-cache gem.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,19 @@ logger = Logger.new($stdout)
 logger.level = Logger::WARN
 
 Tinybucket.configure do |config|
-  # set your logger if you want.
+  # Configure logger if you want.
+  #
+  # optional, default: nil (no logging)
   config.logger = logger
 
-  # configure oauth_token/oauth_secret
+  # Configure cache_store options if you need.
+  #
+  # see https://github.com/plataformatec/faraday-http-cache
+  #
+  # optional, default: nil (disable request cache)
+  config.cache_store_options = { store: Rails.cache, logger: logger }
+
+  # Configure oauth_token/oauth_secret
   config.oauth_token = 'key'
   config.oauth_secret = 'secret'
 end

--- a/lib/tinybucket.rb
+++ b/lib/tinybucket.rb
@@ -10,6 +10,7 @@ require 'faraday'
 require 'faraday_middleware'
 require 'faraday_middleware/response_middleware'
 require 'faraday_middleware/follow_oauth_redirects'
+require 'faraday-http-cache'
 
 require 'active_model'
 

--- a/lib/tinybucket/config.rb
+++ b/lib/tinybucket/config.rb
@@ -1,6 +1,6 @@
 module Tinybucket
   class Config
     include ActiveSupport::Configurable
-    config_accessor :logger, :oauth_token, :oauth_secret
+    config_accessor :logger, :oauth_token, :oauth_secret, :cache_store_options
   end
 end

--- a/lib/tinybucket/connection.rb
+++ b/lib/tinybucket/connection.rb
@@ -36,6 +36,8 @@ module Tinybucket
           consumer_secret: Tinybucket.config.oauth_secret
         }
 
+        configure_response_cache(conn)
+
         conn.request :multipart
         conn.request :url_encoded
         conn.request :oauth, oauth_secrets
@@ -47,6 +49,12 @@ module Tinybucket
 
         conn.adapter Faraday.default_adapter
       end
+    end
+
+    def configure_response_cache(conn)
+      return unless Tinybucket.config.cache_store_options
+
+      conn.use :http_cache, Tinybucket.config.cache_store_options
     end
 
     def stack(parser, options = {}, &block)

--- a/spec/lib/tinybucket_spec.rb
+++ b/spec/lib/tinybucket_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Tinybucket do
     let(:logger) { Logger.new($stdout) }
     let(:oauth_token) { 'test_oauth_token' }
     let(:oauth_secret) { 'test_oauth_secret' }
+    let(:cache_store_options) { { logger: Tinybucket.logger } }
 
     it 'is configurable' do
       expect(config.logger).to be_nil
@@ -24,12 +25,14 @@ RSpec.describe Tinybucket do
       expect do
         Tinybucket.configure do |config|
           config.logger = logger
+          config.cache_store_options = cache_store_options
           config.oauth_token = oauth_token
           config.oauth_secret = oauth_secret
         end
       end.not_to raise_error
 
       expect(config.logger).to eq(logger)
+      expect(config.cache_store_options).to eq(cache_store_options)
       expect(config.oauth_token).to eq(oauth_token)
       expect(config.oauth_secret).to eq(oauth_secret)
     end

--- a/tinybucket.gemspec
+++ b/tinybucket.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activesupport',      ['>= 4.1.6']
   spec.add_runtime_dependency 'faraday',            ['= 0.9.0']
   spec.add_runtime_dependency 'faraday_middleware', ['= 0.9.1']
+  spec.add_runtime_dependency 'faraday-http-cache', ['~> 1.2']
   spec.add_runtime_dependency 'simple_oauth',       ['= 0.2.0']
 
   spec.add_development_dependency 'bundler',     '~> 1.10'


### PR DESCRIPTION
This pull request introduces `cache_store_options` to be able to configure request cache by using [faraday-http-cache gem](https://github.com/plataformatec/faraday-http-cache).

Configure cache_store_options like below If you want to use cache_store.

```ruby
Tinybucket.configure do |config|
  config.cache_store_options = { store: Rails.cache, logger: logger }
end
```
For more detail about `cache_store_options`, see [faraday-http-cache gem](https://github.com/plataformatec/faraday-http-cache).