### PR TITLE
raise error on reloadable method.

### DIFF
--- a/lib/tinybucket/model/concerns/reloadable.rb
+++ b/lib/tinybucket/model/concerns/reloadable.rb
@@ -8,16 +8,12 @@ module Tinybucket
           def load
             return true if @_loaded
 
-            @_loaded = \
-              begin
-                self.attributes = load_model.attributes
-                true
-              rescue => e
-                Tinybucket.logger.error e
-                false
-              end
-
-            @_loaded
+            self.attributes = load_model.attributes
+            @_loaded = true
+          rescue => e
+            @_loaded = false
+            Tinybucket.logger.error e
+            raise e
           end
 
           def loaded?
@@ -26,7 +22,9 @@ module Tinybucket
 
           def reload
             @_loaded = false
-            load
+            # rubocop:disable all
+            self.load
+            # rubocop:enable all
           end
 
           private

--- a/spec/support/model_macros.rb
+++ b/spec/support/model_macros.rb
@@ -38,11 +38,19 @@ module ModelMacros
       end
 
       context 'when load failed' do
+        let(:env) do
+          {
+            htt_method: :get,
+            request_url: 'https://localhost/path/to/resource',
+            status_code: 404,
+            response_body: 'not found'
+          }
+        end
         before do
-          allow(@model).to receive(:load_model).and_raise(ArgumentError)
+          @model.stub(:load_model) { raise Tinybucket::Error::NotFound.new(env) }
         end
 
-        it { expect(subject).to be_falsey }
+        it { expect { subject }.to raise_error(Tinybucket::Error::NotFound) }
       end
     end
 
@@ -76,11 +84,19 @@ module ModelMacros
       end
 
       context 'when load failed' do
+        let(:env) do
+          {
+            htt_method: :get,
+            request_url: 'https://localhost/path/to/resource',
+            status_code: 404,
+            response_body: 'not found'
+          }
+        end
         before do
-          allow(@model).to receive(:load_model).and_raise(ArgumentError)
+          @model.stub(:load_model) { raise Tinybucket::Error::NotFound.new(env) }
         end
 
-        it { expect(subject).to be_falsey }
+        it { expect { subject }.to raise_error(Tinybucket::Error::NotFound) }
       end
     end
   end


### PR DESCRIPTION
Raise error on `reloadable method` call, like 'load', 'reload'.