### PR TITLE
:green_heart: fix deprecation warning.

### DIFF
--- a/spec/support/model_macros.rb
+++ b/spec/support/model_macros.rb
@@ -47,7 +47,7 @@ module ModelMacros
           }
         end
         before do
-          @model.stub(:load_model) { raise Tinybucket::Error::NotFound.new(env) }
+          allow(@model).to receive(:load_model).and_raise(Tinybucket::Error::NotFound.new(env));
         end
 
         it { expect { subject }.to raise_error(Tinybucket::Error::NotFound) }
@@ -93,7 +93,7 @@ module ModelMacros
           }
         end
         before do
-          @model.stub(:load_model) { raise Tinybucket::Error::NotFound.new(env) }
+          allow(@model).to receive(:load_model).and_raise(Tinybucket::Error::NotFound.new(env))
         end
 
         it { expect { subject }.to raise_error(Tinybucket::Error::NotFound) }


### PR DESCRIPTION
Fix deprecation warnings on creating stubbed a model.

```
Deprecation Warnings:

Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /Users/hirakiuc/repos/src/github.com/hirakiuc/tinybucket/spec/support/model_macros.rb:96:in `block (4 levels) in <module:ModelMacros>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.
```