### PR TITLE
Support OAuth2

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ Tinybucket.configure do |config|
   # optional, default: nil (disable request cache)
   config.cache_store_options = { store: Rails.cache, logger: logger }
 
-  # Configure oauth_token/oauth_secret
+  # Configure access_token if you can prepare OAuth2 access_token.
+  config.access_token = 'your_access_token'
+
+  # Configure oauth_token/oauth_secret if you want to use OAuth1.0 authentication.
+  # (This config will be ignored if you configure OAuth2 access_token.)
   config.oauth_token = 'key'
   config.oauth_secret = 'secret'
 end

--- a/lib/tinybucket/config.rb
+++ b/lib/tinybucket/config.rb
@@ -3,6 +3,6 @@
 module Tinybucket
   class Config
     include ActiveSupport::Configurable
-    config_accessor :logger, :oauth_token, :oauth_secret, :cache_store_options
+    config_accessor :logger, :oauth_token, :oauth_secret, :access_token, :cache_store_options
   end
 end

--- a/lib/tinybucket/config.rb
+++ b/lib/tinybucket/config.rb
@@ -3,6 +3,7 @@
 module Tinybucket
   class Config
     include ActiveSupport::Configurable
-    config_accessor :logger, :oauth_token, :oauth_secret, :access_token, :cache_store_options
+    config_accessor :logger, :oauth_token, :oauth_secret,
+                    :access_token, :cache_store_options
   end
 end

--- a/lib/tinybucket/connection.rb
+++ b/lib/tinybucket/connection.rb
@@ -39,23 +39,27 @@ module Tinybucket
         conn.request :multipart
         conn.request :url_encoded
 
-        if Tinybucket.config.access_token
-          conn.request :oauth2, Tinybucket.config.access_token
-        else
-          oauth_secrets = {
-            consumer_key:    Tinybucket.config.oauth_token,
-            consumer_secret: Tinybucket.config.oauth_secret
-          }
-
-          conn.request :oauth, oauth_secrets
-          conn.response :follow_oauth_redirects, oauth_secrets
-        end
+        configure_auth(conn)
 
         conn.response :json, content_type: /\bjson$/
         conn.use Tinybucket::Response::Handler
         conn.use :instrumentation
 
         conn.adapter Faraday.default_adapter
+      end
+    end
+
+    def configure_auth(conn)
+      if Tinybucket.config.access_token
+        conn.request :oauth2, Tinybucket.config.access_token
+      else
+        oauth_secrets = {
+          consumer_key:    Tinybucket.config.oauth_token,
+          consumer_secret: Tinybucket.config.oauth_secret
+        }
+
+        conn.request :oauth, oauth_secrets
+        conn.response :follow_oauth_redirects, oauth_secrets
       end
     end
 

--- a/spec/lib/tinybucket/connection_spec.rb
+++ b/spec/lib/tinybucket/connection_spec.rb
@@ -27,4 +27,32 @@ RSpec.describe Tinybucket::Connection do
       it { expect(subject).to be_instance_of(Faraday::Connection) }
     end
   end
+
+  describe 'configure_auth' do
+    subject(:handlers) { mock_api.connection.builder.handlers }
+
+    context 'with Tinybucket.config.access_token' do
+      before do
+        allow_any_instance_of(Tinybucket::Config).to \
+          receive(:access_token).and_return('test token')
+      end
+
+      it 'should use oauth2 middleware' do
+        expect(handlers).to include(FaradayMiddleware::OAuth2)
+        expect(handlers).not_to include(FaradayMiddleware::OAuth)
+      end
+    end
+
+    context 'without Tinybucket.config.access_token' do
+      before do
+        allow_any_instance_of(Tinybucket::Config).to \
+          receive(:access_token).and_return(nil)
+      end
+
+      it 'should use oauth middleware' do
+        expect(handlers).not_to include(FaradayMiddleware::OAuth2)
+        expect(handlers).to include(FaradayMiddleware::OAuth)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR introduce `access_token` config to support OAuth2 access_token.

## NOTE

This code requires users to prepare the access_token which created by [OAuth2 flow](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html#OAuthonBitbucketCloud-Accesstokens).