### PR TITLE
:green_heart: use rubygems v2.6.9 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: ruby
 before_install:
+  - gem update --system 2.6.9
   - gem install bundler -v 1.13.6
 rvm: 2.3.3
 addons:


### PR DESCRIPTION
fixes #113 .