### PR TITLE
Fix typo in gem name for gem install

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install bitbucket
+    $ gem install tinybucket
 
 ## Usage
 


### PR DESCRIPTION
Was still using older `bitbucket` gem name