### PR TITLE
:shirt: fix rubocop offenses.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,3 +49,9 @@ Style/RedundantFreeze:
 
 Metrics/AbcSize:
   Max: 18
+
+Metrics/LineLength:
+  Max: 100
+  IgnoredPatterns: [
+    '^\s*#'
+  ]

--- a/lib/tinybucket/model/base.rb
+++ b/lib/tinybucket/model/base.rb
@@ -24,9 +24,7 @@ module Tinybucket
           if acceptable_attribute?(key)
             send("#{key}=".intern, value)
           else
-            # rubocop:disable Metrics/LineLength
             logger.warn("Ignored '#{key}' attribute (value: #{value}). [#{self.class}]")
-            # rubocop:enable Metrics/LineLength
           end
         end
       end

--- a/lib/tinybucket/resource/commits.rb
+++ b/lib/tinybucket/resource/commits.rb
@@ -25,7 +25,7 @@ module Tinybucket
       # @param options [Hash]
       # @return [Tinybucket::Iterator]
       def branch(name, options = {})
-        create_enumerator(commits_api, :branch, *[name, options]) do |m|
+        create_enumerator(commits_api, :branch, name, options) do |m|
           inject_repo_keys(m, @repo.repo_keys)
         end
       end


### PR DESCRIPTION
Fixes rubocop offenses.

- Extend max line length from 80 to 100.
- Ignore line length check on comment line.