### PR TITLE
:lipstick: fix "bundle install error"

### DIFF
--- a/tinybucket.gemspec
+++ b/tinybucket.gemspec
@@ -2,7 +2,6 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'tinybucket/version'
-require 'rake'
 
 Gem::Specification.new do |spec|
   spec.name          = 'tinybucket'
@@ -14,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://hirakiuc.github.io/tinybucket/'
   spec.license       = 'MIT'
 
-  spec.files         =  Rake::FileList['lib/**/*', 'LICENSE', 'Rakefile', 'Gemfile', 'tinybucket.gemspec', 'README.md', '.rubocop.yml']
+  spec.files         =  Dir['lib/**/*', 'LICENSE', 'Rakefile', 'Gemfile', 'tinybucket.gemspec', 'README.md', '.rubocop.yml']
   spec.executables   = spec.files.grep(/^bin\//) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ['lib']


### PR DESCRIPTION
In #118, I exclude unnecessary files in gem package.

But this code depends on `rake` and this cause error on executing newly `bundle install`.

By this pull request, I use `Dir.glob` to create the same file list.