### PR TITLE
:bug: fix error on iterating with query params.

### DIFF
--- a/lib/tinybucket/iterator.rb
+++ b/lib/tinybucket/iterator.rb
@@ -68,8 +68,8 @@ module Tinybucket
         if @attrs.empty?
           {}
         else
-          queryParams = URI.parse(@attrs[:next]).query
-          Hash[*queryParams.split(/&|=/).map{|v| URI.unescape(v)}]
+          query = URI.parse(@attrs[:next]).query
+          Hash[*query.split(/&|=/).map { |v| URI.unescape(v) }]
         end
 
       @args[-1].merge!(params)

--- a/lib/tinybucket/iterator.rb
+++ b/lib/tinybucket/iterator.rb
@@ -68,8 +68,8 @@ module Tinybucket
         if @attrs.empty?
           {}
         else
-          unescaped_query = URI.unescape(URI.parse(@attrs[:next]).query)
-          Hash[*unescaped_query.split(/&|=/)]
+          queryParams = URI.parse(@attrs[:next]).query
+          Hash[*queryParams.split(/&|=/).map{|v| URI.unescape(v)}]
         end
 
       @args[-1].merge!(params)


### PR DESCRIPTION
This pull request fixes the issue on iterating any resource with query parameters which contain `=` string. 

Ref: #128 

## Detail

On #133 ,  I've added a new feature to iterate repositories on each project.
The API request is just like below.

> /2.0/repositories/test_team?q=project.key%3D%22TEST%22

When iterating the resource, this gem should add page params to the API request as query parameters like below.

> /2.0/repositories/test_team?page=2&q=project.key%3D%22TEST%22

Before this pull request, there is a bug to parse and modify the query parameter on the iterating resource.

This pull request fixes the behavior to URI.unescape `the query parameter on each key and value`, not `whole query parameter string`. 👍 

 