### PR TITLE
Expose project hash on repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ features
 /.bundle/
 /lib/bundler/man/
 /vendor/
+*.iml

--- a/lib/tinybucket/model/repository.rb
+++ b/lib/tinybucket/model/repository.rb
@@ -43,6 +43,8 @@ module Tinybucket
     #   @return [String]
     # @!attribute [rw] type
     #   @return [String]
+    # # @!attribute [rw] project
+    #   @return [Hash]
     class Repository < Base
       include Tinybucket::Model::Concerns::RepositoryKeys
 
@@ -50,7 +52,7 @@ module Tinybucket
         :scm, :has_wiki, :description, :links, :updated_on,
         :fork_policy, :created_on, :owner, :size, :parent, :uuid,
         :has_issues, :is_private, :full_name, :name, :language,
-        :website, :type
+        :website, :type, :project
 
       def initialize(json)
         super(json)

--- a/lib/tinybucket/model/repository.rb
+++ b/lib/tinybucket/model/repository.rb
@@ -43,7 +43,7 @@ module Tinybucket
     #   @return [String]
     # @!attribute [rw] type
     #   @return [String]
-    # # @!attribute [rw] project
+    # @!attribute [rw] project
     #   @return [Hash]
     class Repository < Base
       include Tinybucket::Model::Concerns::RepositoryKeys

--- a/spec/fixtures/repository.json
+++ b/spec/fixtures/repository.json
@@ -64,6 +64,23 @@
       }
     }
   },
+  "project": {
+    "key": "TEST",
+    "type": "project",
+    "uuid": "{ABC}",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/teams/evzijst/projects/TEST"
+      },
+      "html": {
+        "href": "https://bitbucket.org/account/user/evzijst/projects/TEST"
+      },
+      "avatar": {
+        "href": "https://bitbucket.org/account/user/evzijst/projects/TEST/avatar/123"
+      }
+    },
+    "name": "My Project"
+  },
   "updated_on": "2013-08-26T18:13:07.514065+00:00",
   "size": 17657351,
   "is_private": false,


### PR DESCRIPTION
Repos that are organized by projects (usually within an org) return the project data at the root level. This allows access to that data. 

Thanks for this SDK. Works like a charm otherwise.