### PR TITLE
Implemented Tags API based on the current Branches API

### DIFF
--- a/lib/tinybucket/api.rb
+++ b/lib/tinybucket/api.rb
@@ -7,6 +7,7 @@ module Tinybucket
     [
       :BaseApi,
       :BranchesApi,
+      :TagsApi,
       :BranchRestrictionsApi,
       :BuildStatusApi,
       :CommitsApi,

--- a/lib/tinybucket/api/commits_api.rb
+++ b/lib/tinybucket/api/commits_api.rb
@@ -92,6 +92,22 @@ module Tinybucket
           get_parser(:collection, Tinybucket::Model::Commit)
         )
       end
+
+      # Send 'GET commits for a tag' request
+      #
+      # @see https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/commits
+      #   GET an individual commit
+      #
+      # @param name [String] The branch name or a SHA1 value for the commit.
+      # @param options [Hash]
+      # @return [Tinybucket::Model::Commit]
+      def tag(name, options = {})
+        get_path(
+          path_to_tag(name),
+          options,
+          get_parser(:collection, Tinybucket::Model::Commit)
+        )
+      end
     end
   end
 end

--- a/lib/tinybucket/api/helper.rb
+++ b/lib/tinybucket/api/helper.rb
@@ -9,6 +9,7 @@ module Tinybucket
         :ApiHelper,
         :BranchesHelper,
         :BranchRestrictionsHelper,
+        :TagsHelper,
         :BuildStatusHelper,
         :CommitsHelper,
         :CommentsHelper,

--- a/lib/tinybucket/api/helper/commits_helper.rb
+++ b/lib/tinybucket/api/helper/commits_helper.rb
@@ -24,6 +24,13 @@ module Tinybucket
                      [branch, 'branch'])
         end
 
+        def path_to_tag(tag)
+          build_path(base_path,
+                     'commits',
+                     [tag, 'tag'])
+        end
+
+
         def path_to_approve(revision)
           build_path(base_path,
                      'commit',

--- a/lib/tinybucket/api/helper/tags_helper.rb
+++ b/lib/tinybucket/api/helper/tags_helper.rb
@@ -1,0 +1,27 @@
+module Tinybucket
+  module Api
+    module Helper
+      module TagsHelper
+        include ::Tinybucket::Api::Helper::ApiHelper
+
+        private
+
+        def path_to_list
+          build_path(base_path)
+        end
+
+        def path_to_find(tag)
+          build_path(base_path,
+                     [tag, 'tag'])
+        end
+
+        def base_path
+          build_path('/repositories',
+                     [repo_owner, 'repo_owner'],
+                     [repo_slug, 'repo_slug'],
+                     'refs', 'tags')
+        end
+      end
+    end
+  end
+end

--- a/lib/tinybucket/api/tags_api.rb
+++ b/lib/tinybucket/api/tags_api.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Tinybucket
+  module Api
+    # Tags Api client
+    #
+    # @!attribute [rw] repo_owner
+    #   @return [String] repository owner name.
+    # @!attribute [rw] repo_slug
+    #   @return [String] {https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D repo_slug}.
+    class TagsApi < BaseApi
+      include Tinybucket::Api::Helper::TagsHelper
+
+      attr_accessor :repo_owner, :repo_slug
+
+      # Send 'GET a tags list for a repository' request
+      #
+      # @see https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/refs/tags#get
+      #   GET a tags list for a repository
+      #
+      # @param options [Hash]
+      # @return [Tinybucket::Model::Page]
+      def list(options = {})
+        get_path(
+          path_to_list,
+          options,
+          get_parser(:collection, Tinybucket::Model::Tag)
+        )
+      end
+
+      # Send 'GET an individual tag' request
+      #
+      # @see https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/refs/tags/%7Bname%7D#get
+      #   GET an individual tag
+      #
+      # @param name [String] The tag name
+      # @param options [Hash]
+      # @return [Tinybucket::Model::Tag]
+      def find(name, options = {})
+        get_path(
+          path_to_find(name),
+          options,
+          get_parser(:object, Tinybucket::Model::Tag)
+        )
+      end
+    end
+  end
+end

--- a/lib/tinybucket/model.rb
+++ b/lib/tinybucket/model.rb
@@ -17,6 +17,7 @@ module Tinybucket
       :Project,
       :PullRequest,
       :Repository,
+      :Tag,
       :Team
     ].each do |klass_name|
       autoload klass_name

--- a/lib/tinybucket/model/repository.rb
+++ b/lib/tinybucket/model/repository.rb
@@ -137,7 +137,6 @@ module Tinybucket
         branches_resource.find(branch, options)
       end
 
-      puts "test"
       # Get tags on this repository
       #
       # @param options [Hash]

--- a/lib/tinybucket/model/repository.rb
+++ b/lib/tinybucket/model/repository.rb
@@ -137,6 +137,24 @@ module Tinybucket
         branches_resource.find(branch, options)
       end
 
+      puts "test"
+      # Get tags on this repository
+      #
+      # @param options [Hash]
+      # @return [Tinybucket::Resource::Tags]
+      def tags(options = {})
+        tags_resource(options)
+      end
+
+      # Get the specific tag on this repository.
+      #
+      # @param branch [String]
+      # @param options [Hash]
+      # @return [Tinybucket::Model::Tag]
+      def tag(tag, options = {})
+        tags_resource.find(tag, options)
+      end
+
       # Get the branch restriction information associated with this repository.
       #
       # @param options [Hash]
@@ -181,6 +199,10 @@ module Tinybucket
 
       def branches_resource(options = {})
         Tinybucket::Resource::Branches.new(self, options)
+      end
+
+      def tags_resource(options = {})
+        Tinybucket::Resource::Tags.new(self, options)
       end
 
       def commits_resource(options = {})

--- a/lib/tinybucket/model/tag.rb
+++ b/lib/tinybucket/model/tag.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Tinybucket
+  module Model
+    # Tag
+    #
+    # @see https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/refs/tags
+    #   Tag Resource
+    #
+    # @!attribute [rw] links
+    #   @return [Hash]
+    # @!attribute [rw] type
+    #   @return [String]
+    # @!attribute [rw] name
+    #   @return [String]
+    # @!attribute [rw] repository
+    #   @return [Hash]
+    # @!attribute [rw] target
+    #   @return [Hash]
+    class Tag < Base
+      include Tinybucket::Model::Concerns::RepositoryKeys
+
+      acceptable_attributes :links, :type, :name, :repository, :target, :tagger, :date, :message
+
+      # Returns the commits available for the specific tag
+      #
+      # @param options [Hash]
+      # @return [Tinybucket::Resource::Commits]
+      def commits(options = {})
+        commits_resource.tag(name, options)
+      end
+
+      private
+
+      def commits_resource(options = {})
+        Tinybucket::Resource::Commits.new(self, options)
+      end
+
+      def tags_api
+        create_api('Tags', repo_keys)
+      end
+
+      def load_model
+        tags_api.find(name, {})
+      end
+    end
+  end
+end

--- a/lib/tinybucket/resource.rb
+++ b/lib/tinybucket/resource.rb
@@ -16,6 +16,7 @@ module Tinybucket
       :PullRequests,
       :Repos,
       :Teams,
+      :Tags,
       :Watchers
     ].each do |klass_name|
       autoload klass_name

--- a/lib/tinybucket/resource/commits.rb
+++ b/lib/tinybucket/resource/commits.rb
@@ -30,6 +30,17 @@ module Tinybucket
         end
       end
 
+      # Returns the commits for a specific tag
+      #
+      # @param name [String]
+      # @param options [Hash]
+      # @return [Tinybucket::Iterator]
+      def tag(name, options = {})
+        create_enumerator(commits_api, :tag, name, options) do |m|
+          inject_repo_keys(m, @repo.repo_keys)
+        end
+      end
+
       private
 
       def commits_api

--- a/lib/tinybucket/resource/tags.rb
+++ b/lib/tinybucket/resource/tags.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Tinybucket
+  module Resource
+    class Tags < Tinybucket::Resource::Base
+      def initialize(repo, options)
+        @repo = repo
+        @args = [options]
+      end
+
+      # Find the tag
+      #
+      # @param tag [String]
+      # @param options [Hash]
+      # @return [Tinybucket::Model::Tag]
+      def find(tag, options = {})
+        tags_api.find(tag, options).tap do |m|
+          inject_repo_keys(m, @repo.repo_keys)
+        end
+      end
+
+      private
+
+      def tags_api
+        create_api('Tags', @repo.repo_keys)
+      end
+
+      def enumerator
+        create_enumerator(tags_api, :list, *@args) do |m|
+          inject_repo_keys(m, @repo.repo_keys)
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/repositories/test_owner/test_repo/commits/3.8/get.json
+++ b/spec/fixtures/repositories/test_owner/test_repo/commits/3.8/get.json
@@ -1,0 +1,401 @@
+{
+    "pagelen": 30,
+    "values": [
+        {
+            "hash": "f9d3d51319d6bb5fc7270c2554d7e2a756bbf504",
+            "repository": {
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/test_owner/test_repo"
+                    },
+                    "avatar": {
+                        "href": "https://bitbucket.org/test_owner/test_repo/avatar/32/"
+                    }
+                },
+                "type": "repository",
+                "name": "custom-app",
+                "full_name": "test_owner/test_repo",
+                "uuid": "{3f9415a2-f73c-4c3a-9b12-d430a39731db}"
+            },
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/f9d3d51319d6bb5fc7270c2554d7e2a756bbf504"
+                },
+                "comments": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/f9d3d51319d6bb5fc7270c2554d7e2a756bbf504/comments"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/test_owner/test_repo/commits/f9d3d51319d6bb5fc7270c2554d7e2a756bbf504"
+                },
+                "diff": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/diff/f9d3d51319d6bb5fc7270c2554d7e2a756bbf504"
+                },
+                "approve": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/f9d3d51319d6bb5fc7270c2554d7e2a756bbf504/approve"
+                },
+                "statuses": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/f9d3d51319d6bb5fc7270c2554d7e2a756bbf504/statuses"
+                }
+            },
+            "author": {
+                "raw": "Test User <test_owner@domain.com>",
+                "user": {
+                    "username": "test_owner",
+                    "display_name": "Test User",
+                    "type": "user",
+                    "uuid": "{24e6704e-de5b-4b00-8e3b-6515e16ca38e}",
+                    "links": {
+                        "self": {
+                            "href": "https://api.bitbucket.org/2.0/users/test_owner"
+                        },
+                        "html": {
+                            "href": "https://bitbucket.org/test_owner/"
+                        },
+                        "avatar": {
+                            "href": "https://bitbucket.org/account/test_owner/avatar/32/"
+                        }
+                    }
+                }
+            },
+            "parents": [
+                {
+                    "hash": "63a802e7d94d06c7c4f92cb09a32a99b4dc6fce1",
+                    "type": "commit",
+                    "links": {
+                        "self": {
+                            "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/63a802e7d94d06c7c4f92cb09a32a99b4dc6fce1"
+                        },
+                        "html": {
+                            "href": "https://bitbucket.org/test_owner/test_repo/commits/63a802e7d94d06c7c4f92cb09a32a99b4dc6fce1"
+                        }
+                    }
+                },
+                {
+                    "hash": "03739772ceedecda6a4f2f0f6b11333476c10f63",
+                    "type": "commit",
+                    "links": {
+                        "self": {
+                            "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/03739772ceedecda6a4f2f0f6b11333476c10f63"
+                        },
+                        "html": {
+                            "href": "https://bitbucket.org/test_owner/test_repo/commits/03739772ceedecda6a4f2f0f6b11333476c10f63"
+                        }
+                    }
+                }
+            ],
+            "date": "2016-10-02T15:15:23+00:00",
+            "message": "Merge pull request #1 from test_owner/qa\n\nQa",
+            "type": "commit"
+        },
+        {
+            "hash": "03739772ceedecda6a4f2f0f6b11333476c10f63",
+            "repository": {
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/test_owner/test_repo"
+                    },
+                    "avatar": {
+                        "href": "https://bitbucket.org/test_owner/test_repo/avatar/32/"
+                    }
+                },
+                "type": "repository",
+                "name": "custom-app",
+                "full_name": "test_owner/test_repo",
+                "uuid": "{3f9415a2-f73c-4c3a-9b12-d430a39731db}"
+            },
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/03739772ceedecda6a4f2f0f6b11333476c10f63"
+                },
+                "comments": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/03739772ceedecda6a4f2f0f6b11333476c10f63/comments"
+                },
+                "patch": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/patch/03739772ceedecda6a4f2f0f6b11333476c10f63"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/test_owner/test_repo/commits/03739772ceedecda6a4f2f0f6b11333476c10f63"
+                },
+                "diff": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/diff/03739772ceedecda6a4f2f0f6b11333476c10f63"
+                },
+                "approve": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/03739772ceedecda6a4f2f0f6b11333476c10f63/approve"
+                },
+                "statuses": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/03739772ceedecda6a4f2f0f6b11333476c10f63/statuses"
+                }
+            },
+            "author": {
+                "raw": "Test User <test_owner@domain.com>",
+                "user": {
+                    "username": "test_owner",
+                    "display_name": "Test User",
+                    "type": "user",
+                    "uuid": "{24e6704e-de5b-4b00-8e3b-6515e16ca38e}",
+                    "links": {
+                        "self": {
+                            "href": "https://api.bitbucket.org/2.0/users/test_owner"
+                        },
+                        "html": {
+                            "href": "https://bitbucket.org/test_owner/"
+                        },
+                        "avatar": {
+                            "href": "https://bitbucket.org/account/test_owner/avatar/32/"
+                        }
+                    }
+                }
+            },
+            "parents": [
+                {
+                    "hash": "2d8876460495fa7207570a3995171ddd1b3f885e",
+                    "type": "commit",
+                    "links": {
+                        "self": {
+                            "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/2d8876460495fa7207570a3995171ddd1b3f885e"
+                        },
+                        "html": {
+                            "href": "https://bitbucket.org/test_owner/test_repo/commits/2d8876460495fa7207570a3995171ddd1b3f885e"
+                        }
+                    }
+                }
+            ],
+            "date": "2016-10-02T15:13:34+00:00",
+            "message": "Update index.php",
+            "type": "commit"
+        },
+        {
+            "hash": "63a802e7d94d06c7c4f92cb09a32a99b4dc6fce1",
+            "repository": {
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/test_owner/test_repo"
+                    },
+                    "avatar": {
+                        "href": "https://bitbucket.org/test_owner/test_repo/avatar/32/"
+                    }
+                },
+                "type": "repository",
+                "name": "custom-app",
+                "full_name": "test_owner/test_repo",
+                "uuid": "{3f9415a2-f73c-4c3a-9b12-d430a39731db}"
+            },
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/63a802e7d94d06c7c4f92cb09a32a99b4dc6fce1"
+                },
+                "comments": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/63a802e7d94d06c7c4f92cb09a32a99b4dc6fce1/comments"
+                },
+                "patch": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/patch/63a802e7d94d06c7c4f92cb09a32a99b4dc6fce1"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/test_owner/test_repo/commits/63a802e7d94d06c7c4f92cb09a32a99b4dc6fce1"
+                },
+                "diff": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/diff/63a802e7d94d06c7c4f92cb09a32a99b4dc6fce1"
+                },
+                "approve": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/63a802e7d94d06c7c4f92cb09a32a99b4dc6fce1/approve"
+                },
+                "statuses": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/63a802e7d94d06c7c4f92cb09a32a99b4dc6fce1/statuses"
+                }
+            },
+            "author": {
+                "raw": "Test User <test_owner@domain.com>",
+                "user": {
+                    "username": "test_owner",
+                    "display_name": "Test User",
+                    "type": "user",
+                    "uuid": "{ed0210ba-9709-424c-934f-4ba5d9a39c7c}",
+                    "links": {
+                        "self": {
+                            "href": "https://api.bitbucket.org/2.0/users/test_owner"
+                        },
+                        "html": {
+                            "href": "https://bitbucket.org/test_owner/"
+                        },
+                        "avatar": {
+                            "href": "https://bitbucket.org/account/test_owner/avatar/32/"
+                        }
+                    }
+                }
+            },
+            "parents": [
+                {
+                    "hash": "8fa23a2829a99270378a91807501cd474985ae78",
+                    "type": "commit",
+                    "links": {
+                        "self": {
+                            "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/8fa23a2829a99270378a91807501cd474985ae78"
+                        },
+                        "html": {
+                            "href": "https://bitbucket.org/test_owner/test_repo/commits/8fa23a2829a99270378a91807501cd474985ae78"
+                        }
+                    }
+                }
+            ],
+            "date": "2016-04-20T22:49:15+00:00",
+            "message": "fix demo package.json\n",
+            "type": "commit"
+        },
+        {
+            "hash": "2d8876460495fa7207570a3995171ddd1b3f885e",
+            "repository": {
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/test_owner/test_repo"
+                    },
+                    "avatar": {
+                        "href": "https://bitbucket.org/test_owner/test_repo/avatar/32/"
+                    }
+                },
+                "type": "repository",
+                "name": "custom-app",
+                "full_name": "test_owner/test_repo",
+                "uuid": "{3f9415a2-f73c-4c3a-9b12-d430a39731db}"
+            },
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/2d8876460495fa7207570a3995171ddd1b3f885e"
+                },
+                "comments": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/2d8876460495fa7207570a3995171ddd1b3f885e/comments"
+                },
+                "patch": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/patch/2d8876460495fa7207570a3995171ddd1b3f885e"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/test_owner/test_repo/commits/2d8876460495fa7207570a3995171ddd1b3f885e"
+                },
+                "diff": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/diff/2d8876460495fa7207570a3995171ddd1b3f885e"
+                },
+                "approve": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/2d8876460495fa7207570a3995171ddd1b3f885e/approve"
+                },
+                "statuses": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/2d8876460495fa7207570a3995171ddd1b3f885e/statuses"
+                }
+            },
+            "author": {
+                "raw": "Test User <test_owner@domain.com>",
+                "user": {
+                    "username": "test_owner",
+                    "display_name": "Test User",
+                    "type": "user",
+                    "uuid": "{ed0210ba-9709-424c-934f-4ba5d9a39c7c}",
+                    "links": {
+                        "self": {
+                            "href": "https://api.bitbucket.org/2.0/users/test_owner"
+                        },
+                        "html": {
+                            "href": "https://bitbucket.org/test_owner/"
+                        },
+                        "avatar": {
+                            "href": "https://bitbucket.org/account/test_owner/avatar/32/"
+                        }
+                    }
+                }
+            },
+            "parents": [
+                {
+                    "hash": "8fa23a2829a99270378a91807501cd474985ae78",
+                    "type": "commit",
+                    "links": {
+                        "self": {
+                            "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/8fa23a2829a99270378a91807501cd474985ae78"
+                        },
+                        "html": {
+                            "href": "https://bitbucket.org/test_owner/test_repo/commits/8fa23a2829a99270378a91807501cd474985ae78"
+                        }
+                    }
+                }
+            ],
+            "date": "2016-04-20T22:48:44+00:00",
+            "message": "fix demo package.json\n",
+            "type": "commit"
+        },
+        {
+            "hash": "8fa23a2829a99270378a91807501cd474985ae78",
+            "repository": {
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/test_owner/test_repo"
+                    },
+                    "avatar": {
+                        "href": "https://bitbucket.org/test_owner/test_repo/avatar/32/"
+                    }
+                },
+                "type": "repository",
+                "name": "custom-app",
+                "full_name": "test_owner/test_repo",
+                "uuid": "{3f9415a2-f73c-4c3a-9b12-d430a39731db}"
+            },
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/8fa23a2829a99270378a91807501cd474985ae78"
+                },
+                "comments": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/8fa23a2829a99270378a91807501cd474985ae78/comments"
+                },
+                "patch": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/patch/8fa23a2829a99270378a91807501cd474985ae78"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/test_owner/test_repo/commits/8fa23a2829a99270378a91807501cd474985ae78"
+                },
+                "diff": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/diff/8fa23a2829a99270378a91807501cd474985ae78"
+                },
+                "approve": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/8fa23a2829a99270378a91807501cd474985ae78/approve"
+                },
+                "statuses": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/test_owner/test_repo/commit/8fa23a2829a99270378a91807501cd474985ae78/statuses"
+                }
+            },
+            "author": {
+                "raw": "Test User <test_owner@domain.com>",
+                "user": {
+                    "username": "test_owner",
+                    "display_name": "Test User",
+                    "type": "user",
+                    "uuid": "{ed0210ba-9709-424c-934f-4ba5d9a39c7c}",
+                    "links": {
+                        "self": {
+                            "href": "https://api.bitbucket.org/2.0/users/test_owner"
+                        },
+                        "html": {
+                            "href": "https://bitbucket.org/test_owner/"
+                        },
+                        "avatar": {
+                            "href": "https://bitbucket.org/account/test_owner/avatar/32/"
+                        }
+                    }
+                }
+            },
+            "parents": [],
+            "date": "2016-04-15T17:22:57+00:00",
+            "message": "add some test files\n",
+            "type": "commit"
+        }
+    ]
+}

--- a/spec/fixtures/tag.json
+++ b/spec/fixtures/tag.json
@@ -1,0 +1,121 @@
+{
+  "name": "3.8",
+  "links": {
+    "commits": {
+      "href": "https://api.bitbucket.org/2.0/repositories/seanfarley/hg/commits/3.8"
+    },
+    "self": {
+      "href": "https://api.bitbucket.org/2.0/repositories/seanfarley/hg/refs/tags/3.8"
+    },
+    "html": {
+      "href": "https://bitbucket.org/seanfarley/hg/commits/tag/3.8"
+    }
+  },
+  "tagger": {
+    "raw": "Matt Mackall <mpm@selenic.com>",
+    "type": "author",
+    "user": {
+      "username": "mpmselenic",
+      "nickname": "mpmselenic",
+      "display_name": "Matt Mackall",
+      "type": "user",
+      "uuid": "{a4934530-db4c-419c-a478-9ab4964c2ee7}",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/users/mpmselenic"
+        },
+        "html": {
+          "href": "https://bitbucket.org/mpmselenic/"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/mpmselenic/avatar/32/"
+        }
+      }
+    }
+  },
+  "date": "2016-05-01T18:52:25+00:00",
+  "message": "Added tag 3.8 for changeset f85de28eae32",
+  "type": "tag",
+  "target": {
+    "hash": "f85de28eae32e7d3064b1a1321309071bbaaa069",
+    "repository": {
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/seanfarley/hg"
+        },
+        "html": {
+          "href": "https://bitbucket.org/seanfarley/hg"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/seanfarley/hg/avatar/32/"
+        }
+      },
+      "type": "repository",
+      "name": "hg",
+      "full_name": "seanfarley/hg",
+      "uuid": "{c75687fb-e99d-4579-9087-190dbd406d30}"
+    },
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/seanfarley/hg/commit/f85de28eae32e7d3064b1a1321309071bbaaa069"
+      },
+      "comments": {
+        "href": "https://api.bitbucket.org/2.0/repositories/seanfarley/hg/commit/f85de28eae32e7d3064b1a1321309071bbaaa069/comments"
+      },
+      "patch": {
+        "href": "https://api.bitbucket.org/2.0/repositories/seanfarley/hg/patch/f85de28eae32e7d3064b1a1321309071bbaaa069"
+      },
+      "html": {
+        "href": "https://bitbucket.org/seanfarley/hg/commits/f85de28eae32e7d3064b1a1321309071bbaaa069"
+      },
+      "diff": {
+        "href": "https://api.bitbucket.org/2.0/repositories/seanfarley/hg/diff/f85de28eae32e7d3064b1a1321309071bbaaa069"
+      },
+      "approve": {
+        "href": "https://api.bitbucket.org/2.0/repositories/seanfarley/hg/commit/f85de28eae32e7d3064b1a1321309071bbaaa069/approve"
+      },
+      "statuses": {
+        "href": "https://api.bitbucket.org/2.0/repositories/seanfarley/hg/commit/f85de28eae32e7d3064b1a1321309071bbaaa069/statuses"
+      }
+    },
+    "author": {
+      "raw": "Sean Farley <sean@farley.io>",
+      "type": "author",
+      "user": {
+        "username": "seanfarley",
+        "nickname": "seanfarley",
+        "display_name": "Sean Farley",
+        "type": "user",
+        "uuid": "{a295f8a8-5876-4d43-89b5-3ad8c6c3c51d}",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/users/seanfarley"
+          },
+          "html": {
+            "href": "https://bitbucket.org/seanfarley/"
+          },
+          "avatar": {
+            "href": "https://bitbucket.org/account/seanfarley/avatar/32/"
+          }
+        }
+      }
+    },
+    "parents": [
+      {
+        "hash": "9a98d0e5b07fc60887f9d3d34d9ac7d536f470d2",
+        "type": "commit",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/seanfarley/hg/commit/9a98d0e5b07fc60887f9d3d34d9ac7d536f470d2"
+          },
+          "html": {
+            "href": "https://bitbucket.org/seanfarley/hg/commits/9a98d0e5b07fc60887f9d3d34d9ac7d536f470d2"
+          }
+        }
+      }
+    ],
+    "date": "2016-05-01T04:21:17+00:00",
+    "message": "debian: alphabetize build deps",
+    "type": "commit"
+  }
+}

--- a/spec/lib/tinybucket/api/tags_api_spec.rb
+++ b/spec/lib/tinybucket/api/tags_api_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Api::TagsApi do
+  include ApiResponseMacros
+
+  let(:tag) { "3.8" }
+  let(:request_path) { nil }
+  let(:options) { {} }
+  let(:owner) { 'test_owner' }
+  let(:slug)  { 'test_repo' }
+
+  let(:api) do
+    api = Tinybucket::Api::TagsApi.new
+    api.repo_owner = owner
+    api.repo_slug  = slug
+    api
+  end
+
+  it { expect(api).to be_a_kind_of(Tinybucket::Api::BaseApi) }
+
+  let(:request_method) { :get }
+  let(:stub_options) { nil }
+
+  before do
+    if request_path
+      opts = stub_options.present? ? stub_options : {}
+      stub_apiresponse(request_method, request_path, opts)
+    end
+  end
+
+  describe 'list' do
+    subject { api.list(options) }
+
+    context 'without owner' do
+      let(:owner) { nil }
+      it { expect { subject }.to raise_error(ArgumentError) }
+    end
+
+    context 'without slug' do
+      let(:slug) { nil }
+      it { expect { subject }.to raise_error(ArgumentError) }
+    end
+
+    context 'with owner and slug' do
+      let(:request_path) { "/repositories/#{owner}/#{slug}/refs/tags" }
+      it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
+    end
+  end
+
+  describe 'find' do
+    subject { api.find(tag, options) }
+
+    context 'without owner' do
+      let(:owner) { nil }
+      it { expect { subject }.to raise_error(ArgumentError) }
+    end
+
+    context 'without slug' do
+      let(:slug) { nil }
+      it { expect { subject }.to raise_error(ArgumentError) }
+    end
+
+    context 'with owner and slug' do
+      let(:request_path) do
+        "/repositories/#{owner}/#{slug}/refs/tags/#{tag}"
+      end
+      it { expect(subject).to be_instance_of(Tinybucket::Model::Tag) }
+    end
+  end
+end

--- a/spec/lib/tinybucket/model/tag_spec.rb
+++ b/spec/lib/tinybucket/model/tag_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Model::Tag do
+  include ApiResponseMacros
+  include ModelMacros
+
+  let(:model_json) { load_json_fixture('tag') }
+
+  let(:request_path) { nil }
+
+  let(:owner) { 'test_owner' }
+  let(:slug) { 'test_repo' }
+
+  let(:model) do
+    m = Tinybucket::Model::Tag.new(model_json)
+    m.repo_owner = owner
+    m.repo_slug  = slug
+    m
+  end
+
+  let(:request_method) { :get }
+  let(:stub_options) { nil }
+
+  before do
+    if request_path
+      opts = stub_options.present? ? stub_options : {}
+      stub_apiresponse(request_method, request_path, opts)
+    end
+  end
+
+  it_behaves_like 'model has acceptable_attributes',
+                  Tinybucket::Model::Tag,
+                  load_json_fixture('tag')
+
+  describe 'model can reloadable' do
+    let(:tag) { Tinybucket::Model::Tag.new({}) }
+    before { @model = tag }
+    it_behaves_like 'the model is reloadable'
+  end
+
+  describe 'commits' do
+    let(:request_path) { "/repositories/#{owner}/#{slug}/commits/#{model.name}" }
+    subject { model.commits }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Enumerator) }
+    it { expect(subject).to all( be_an_instance_of Tinybucket::Model::Commit) }
+  end
+end

--- a/spec/lib/tinybucket/resource/tags_spec.rb
+++ b/spec/lib/tinybucket/resource/tags_spec.rb
@@ -1,0 +1,45 @@
+
+require 'spec_helper'
+
+RSpec.describe Tinybucket::Resource::Tags do
+  include ApiResponseMacros
+
+  let(:tag) { "3.8" }
+  let(:owner) { 'test_owner' }
+  let(:slug) { 'test_repo' }
+
+  let(:repo) do
+    Tinybucket::Model::Repository.new({}).tap do |m|
+      m.repo_owner = owner
+      m.repo_slug  = slug
+    end
+  end
+
+  let(:options) { {} }
+  let(:resource) { Tinybucket::Resource::Tags.new(repo, options) }
+
+  describe '#find' do
+    let(:request_path) { "/repositories/#{owner}/#{slug}/refs/tags/#{tag}" }
+    before { stub_apiresponse(:get, request_path) }
+    subject { resource.find(tag) }
+    it { expect(subject).to be_an_instance_of(Tinybucket::Model::Tag) }
+  end
+
+  describe 'Enumerable Methods' do
+    let(:request_path) { "/repositories/#{owner}/#{slug}/refs/tags" }
+    before { stub_enum_response(:get, request_path) }
+
+    describe '#take(1)' do
+      subject { resource.take(1) }
+      it { expect(subject).to be_an_instance_of(Array) }
+    end
+
+    describe '#each' do
+      it 'iterate models' do
+        resource.each do |m|
+          expect(m).to be_an_instance_of(Tinybucket::Model::Tag)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
So. I needed the Tags API to work for a pet project of mine, so I did it basically copying all the Branch related stuff and renaming appropriately fixing stuff when necessary.

Dont't know if that's the way you would approach that. Maybe generalizing an Entity that could be used for both tags and branches would be better since they work pretty much the same way.