### PR TITLE
Repos resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ repos  = bucket.repos('someone')
 repos = bucket.repos('myname')
 
 # [x] POST (create) a new repository
-repos.create(params)
+repos.create('repo-slug', params)
 
 # [x] GET a repository
 repos.find('repo_slug', params)

--- a/README.md
+++ b/README.md
@@ -152,8 +152,11 @@ repos  = bucket.repos('someone')
 ```ruby
 repos = bucket.repos('myname')
 
-# [ ] POST a new repository
+# [x] POST (create) a new repository
 repos.create(params)
+
+# [x] GET a repository
+repos.find('repo_slug', params)
 ```
 
 ###### Object Methods
@@ -166,7 +169,10 @@ repo = bucket.repo('someone', 'great_repo')
 # (Load the repository attributes from Bitbucket WebAPI)
 repo.load
 
-# [ ] DELETE a repository
+# [x] PUT (update) a repository
+repo.update(params)
+
+# [x] DELETE a repository
 repo.destroy
 
 # [x] GET a list of watchers

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,11 @@ require 'bundler/setup'
 
 require "bundler/gem_tasks"
 
+desc 'launch an irb console with the gem loaded'
+task :console do
+  exec 'irb -I lib -r tinybucket'
+end
+
 desc 'cleanup rcov, doc directories'
 task :clean do
   rm_rf 'coverage'

--- a/lib/tinybucket/api/helper/repo_helper.rb
+++ b/lib/tinybucket/api/helper/repo_helper.rb
@@ -8,6 +8,12 @@ module Tinybucket
 
         private
 
+        def path_to_find
+          build_path('/repositories',
+                     [repo_owner, 'repo_owner'],
+                     [repo_slug, 'repo_slug'])
+        end
+
         def path_to_put
           build_path('/repositories',
                      [repo_owner, 'repo_owner'],

--- a/lib/tinybucket/api/helper/repo_helper.rb
+++ b/lib/tinybucket/api/helper/repo_helper.rb
@@ -8,8 +8,16 @@ module Tinybucket
 
         private
 
-        def path_to_find
-          base_path
+        def path_to_put
+          build_path('/repositories',
+                     [repo_owner, 'repo_owner'],
+                     [repo_slug, 'repo_slug'])
+        end
+
+        def path_to_delete
+          build_path('/repositories',
+                     [repo_owner, 'repo_owner'],
+                     [repo_slug, 'repo_slug'])
         end
 
         def path_to_watchers

--- a/lib/tinybucket/api/helper/repos_helper.rb
+++ b/lib/tinybucket/api/helper/repos_helper.rb
@@ -8,7 +8,7 @@ module Tinybucket
 
         private
 
-        def path_to_list(owner = nil, options)
+        def path_to_list(owner = nil, options = {})
           return base_path if owner.blank?
           build_path(base_path, [owner, 'owner'])
         end

--- a/lib/tinybucket/api/helper/repos_helper.rb
+++ b/lib/tinybucket/api/helper/repos_helper.rb
@@ -8,8 +8,7 @@ module Tinybucket
 
         private
 
-        def path_to_list(options)
-          owner = options[:owner]
+        def path_to_list(owner = nil, options)
           return base_path if owner.blank?
           build_path(base_path, [owner, 'owner'])
         end

--- a/lib/tinybucket/api/helper/repos_helper.rb
+++ b/lib/tinybucket/api/helper/repos_helper.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 module Tinybucket
   module Api
     module Helper
@@ -8,9 +7,18 @@ module Tinybucket
 
         private
 
-        def path_to_list(owner = nil, _options = {})
+        def path_to_list(options = {})
+          owner = options.delete(:owner)
           return base_path if owner.blank?
           build_path(base_path, [owner, 'owner'])
+        end
+
+        def path_to_find(repo_owner, repo_slug)
+          build_path(base_path, [repo_owner, 'owner'], [repo_slug, 'slug'])
+        end
+
+        def path_to_post(repo_owner, repo_slug)
+          build_path(base_path, [repo_owner, 'owner'], [repo_slug, 'slug'])
         end
 
         def base_path

--- a/lib/tinybucket/api/helper/repos_helper.rb
+++ b/lib/tinybucket/api/helper/repos_helper.rb
@@ -8,7 +8,7 @@ module Tinybucket
 
         private
 
-        def path_to_list(owner = nil, options = {})
+        def path_to_list(owner = nil, _options = {})
           return base_path if owner.blank?
           build_path(base_path, [owner, 'owner'])
         end

--- a/lib/tinybucket/api/repo_api.rb
+++ b/lib/tinybucket/api/repo_api.rb
@@ -16,6 +16,17 @@ module Tinybucket
 
       attr_accessor :repo_owner, :repo_slug
 
+      # Send 'GET a repository' request
+      #
+      # @param options [Hash]
+      # @return [Tinybucket::Model::Repository]
+      def find(options = {})
+        get_path(
+          path_to_find,
+          options,
+          get_parser(:object, Tinybucket::Model::Repository)
+        )
+      end
 
       # Send 'PUT (update) an existing repository' request
       #

--- a/lib/tinybucket/api/repo_api.rb
+++ b/lib/tinybucket/api/repo_api.rb
@@ -16,13 +16,26 @@ module Tinybucket
 
       attr_accessor :repo_owner, :repo_slug
 
-      # Send 'GET a repository' request
+
+      # Send 'PUT (update) an existing repository' request
       #
       # @param options [Hash]
       # @return [Tinybucket::Model::Repository]
-      def find(options = {})
-        get_path(
-          path_to_find,
+      def put(options = {})
+        put_path(
+          path_to_put,
+          options,
+          get_parser(:object, Tinybucket::Model::Repository)
+        )
+      end
+
+      # Send 'DELETE an existing repository' request
+      #
+      # @param options [Hash]
+      # @return [Tinybucket::Model::Repository]
+      def delete(options = {})
+        delete_path(
+          path_to_delete,
           options,
           get_parser(:object, Tinybucket::Model::Repository)
         )

--- a/lib/tinybucket/api/repos_api.rb
+++ b/lib/tinybucket/api/repos_api.rb
@@ -6,20 +6,20 @@ module Tinybucket
     class ReposApi < BaseApi
       include Tinybucket::Api::Helper::ReposHelper
 
-      # Send 'GET a list of repositories for an account' request
+      # Send 'GET a list of repositories for an account' request or public ones if no account specified
       #
       # @see https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories
-      #   GET a list of repositories for an account
+      # @see https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D
       #
-      # @param options [Hash]
+      #   GET a list of repositories for an account or public ones if none specified
+      #
+      # @param owner [String] The name of the account
+      # @param options [Hash] Configuration options for the request
       # @return [Tinybucket::Model::Page]
-      def list(options = {})
-        opts = options.clone
-        opts.delete(:owner)
-
+      def list(owner=nil, options = {})
         get_path(
-          path_to_list(options),
-          opts,
+          path_to_list(owner, options),
+          options,
           get_parser(:collection, Tinybucket::Model::Repository)
         )
       end

--- a/lib/tinybucket/api/repos_api.rb
+++ b/lib/tinybucket/api/repos_api.rb
@@ -5,22 +5,53 @@ module Tinybucket
     # Repos Api client
     class ReposApi < BaseApi
       include Tinybucket::Api::Helper::ReposHelper
-
-      # Send 'GET a list of repositories for an account' request or public ones if no account specified
+    
       #
-      # @see https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories
-      # @see https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D
+      # GET a list of repositories for an account or public ones if none specified
       #
-      #   GET a list of repositories for an account or public ones if none specified
+      # @see https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories#get
+      # @see https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D#get
       #
       # @param owner [String] The name of the account
       # @param options [Hash] Configuration options for the request
       # @return [Tinybucket::Model::Page]
-      def list(owner = nil, options = {})
+      def list(options = {})
         get_path(
-          path_to_list(owner, options),
+          path_to_list(options),
           options,
           get_parser(:collection, Tinybucket::Model::Repository)
+        )
+      end
+
+      #
+      # GET the identified repository for the given account, nil otherwise
+      #
+      # @see https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D#get
+      #
+      # @param owner [String] The name of the account
+      # @param options [Hash] Configuration options for the request
+      # @return [Tinybucket::Model::Page]
+      def find(repo_owner, repo_slug, options = {})
+        get_path(
+          path_to_find(repo_owner, repo_slug),
+          options,
+          get_parser(:object, Tinybucket::Model::Repository)
+        )
+      end
+
+      #
+      # POST (create) a new repository with the provided information for the given account
+      #
+      # @see https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D#post
+      #
+      # @param owner [String] The name of the account
+      # @param options [Hash] Configuration options for the request
+      # @return [Tinybucket::Model::Page]
+      def create(repo_owner, repo_slug, options = {})
+        post_path(
+          path_to_post(repo_owner, repo_slug),
+          options,
+          get_parser(:object, Tinybucket::Model::Repository)
         )
       end
     end

--- a/lib/tinybucket/api/repos_api.rb
+++ b/lib/tinybucket/api/repos_api.rb
@@ -16,7 +16,7 @@ module Tinybucket
       # @param owner [String] The name of the account
       # @param options [Hash] Configuration options for the request
       # @return [Tinybucket::Model::Page]
-      def list(owner=nil, options = {})
+      def list(owner = nil, options = {})
         get_path(
           path_to_list(owner, options),
           options,

--- a/lib/tinybucket/model/repository.rb
+++ b/lib/tinybucket/model/repository.rb
@@ -61,12 +61,22 @@ module Tinybucket
         @repo_owner, @repo_slug = full_name.split('/')
       end
 
-      # Remove this repository
+
+      # Update this repository (remotely and the current instance)
       #
-      # @todo to be implemented.
-      # @raise [NotImplementedError] to be implemented.
+      # @param options [Hash] Attributes to be updated for current repository
+      # @return [Tinybucket::Model::Repository] The updated repository
+      def update(options)
+        self.attributes = repo_api.put(options).attributes
+        @repo_owner, @repo_slug = full_name.split('/')
+        self
+      end
+
+      # Destroy this repository
+      #
+      # @return [NilClass]
       def destroy
-        raise NotImplementedError
+        repo_api.delete
       end
 
       # Get pull requests on thie repository.

--- a/lib/tinybucket/request.rb
+++ b/lib/tinybucket/request.rb
@@ -39,7 +39,8 @@ module Tinybucket
           request.url(path, params)
         when :post, :put, :patch
           request.path = path
-          request.body = extract_data_from_params(params) unless params.empty?
+          request.body = extract_data_from_params(params).to_json unless params.empty?
+          request.headers['Content-Type'] = 'application/json'
         else
           raise ArgumentError, 'unknown http method: ' + method
         end

--- a/lib/tinybucket/resource/repos.rb
+++ b/lib/tinybucket/resource/repos.rb
@@ -3,9 +3,13 @@
 module Tinybucket
   module Resource
     class Repos < Base
-      def initialize(owner, options)
+      def initialize(owner = nil, options = {})
         @owner = owner
         @args = [options]
+      end
+
+      def list(options = {})
+        repos_api.list(@owner, options)
       end
 
       def create(_options)

--- a/lib/tinybucket/resource/repos.rb
+++ b/lib/tinybucket/resource/repos.rb
@@ -8,16 +8,40 @@ module Tinybucket
         @args = [options]
       end
 
+      # List repositories (public ones if no owner provided, owned ones otherwise)
+      #
+      # @param options [Hash] Configuration options
+      # @return [Tinybucket::Model::Page] Paginated repositories
       def list(options = {})
-        repos_api.list(@owner, options)
+        options[:owner] = @owner if @owner.present?
+        repos_api.list(options)
       end
 
-      def create(_options)
-        raise NotImplementedError
+      # Finds the repository defined by the given owner and slug
+      #
+      # @param repo_slug [String] The repository slug identifier
+      # @param options [Hash]
+      # @return [Tinybucket::Model::Repository, NilClass] The identified repository if present and accessible
+      def find(repo_slug, options = {})
+        return nil unless @owner.present? and repo_slug.present?
+        repos_api.find(@owner, repo_slug, options)
       end
 
-      def find(_options)
-        raise NotImplementedError
+      # Creates a new repository with the attributes provided
+      #
+      # @param repo_slug [String] The repository slug identifier
+      # @param options [Hash] Repository attributes
+      # @return [Tinybucket::Model::Repository] The created repository
+      def create(repo_slug, options = {})
+        unless @owner.present?
+          raise ArgumentError,
+                'must provide an owner in order to create a repository'
+        end
+        unless repo_slug.present?
+          raise ArgumentError,
+                'must provide a repo slug in order to create a repository'
+        end
+        repos_api.create(@owner, repo_slug, options)
       end
 
       private

--- a/spec/fixtures/repositories/test_owner/get.json
+++ b/spec/fixtures/repositories/test_owner/get.json
@@ -56,7 +56,7 @@
       "full_name": "evzijst/atlassian-connect-fork",
       "has_issues": false,
       "owner": {
-        "username": "evzijst",
+        "username": "test_owner",
         "display_name": "Erik van Zijst",
         "links": {
           "self": {

--- a/spec/fixtures/repositories/test_owner/test_repo/post.json
+++ b/spec/fixtures/repositories/test_owner/test_repo/post.json
@@ -1,0 +1,71 @@
+{
+  "scm": "git",
+  "has_wiki": false,
+  "description": "",
+  "links": {
+    "watchers": {
+      "href": "https://api.bitbucket.org/2.0/repositories/evzijst/atlassian-connect-fork/watchers"
+    },
+    "commits": {
+      "href": "https://api.bitbucket.org/2.0/repositories/evzijst/atlassian-connect-fork/commits"
+    },
+    "self": {
+      "href": "https://api.bitbucket.org/2.0/repositories/evzijst/atlassian-connect-fork"
+    },
+    "html": {
+      "href": "https://bitbucket.org/evzijst/atlassian-connect-fork"
+    },
+    "avatar": {
+      "href": "https://bitbucket.org/m/3a846b46851a/img/language-avatars/default_16.png"
+    },
+    "forks": {
+      "href": "https://api.bitbucket.org/2.0/repositories/evzijst/atlassian-connect-fork/forks"
+    },
+    "clone": [
+      {
+        "href": "https://bitbucket.org/evzijst/atlassian-connect-fork.git",
+        "name": "https"
+      },
+      {
+        "href": "ssh://git@bitbucket.org/evzijst/atlassian-connect-fork.git",
+        "name": "ssh"
+      }
+    ],
+    "pullrequests": {
+      "href": "https://api.bitbucket.org/2.0/repositories/evzijst/atlassian-connect-fork/pullrequests"
+    }
+  },
+  "fork_policy": "allow_forks",
+  "language": "",
+  "created_on": "2013-08-26T18:13:07.339080+00:00",
+  "parent": {
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/evzijst/atlassian-connect"
+      },
+      "avatar": {
+        "href": "https://bitbucket-assetroot.s3.amazonaws.com/m/3a846b46851a/img/language-avatars/default_16.png"
+      }
+    },
+    "full_name": "evzijst/atlassian-connect",
+    "name": "atlassian-connect"
+  },
+  "full_name": "evzijst/atlassian-connect-fork",
+  "has_issues": false,
+  "owner": {
+    "username": "evzijst",
+    "display_name": "Erik van Zijst",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/users/evzijst"
+      },
+      "avatar": {
+        "href": "https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2013/Oct/28/evzijst-avatar-3454044670-3_avatar.png"
+      }
+    }
+  },
+  "updated_on": "2013-08-26T18:13:07.514065+00:00",
+  "size": 17657351,
+  "is_private": false,
+  "name": "atlassian-connect-fork"
+}

--- a/spec/fixtures/repositories/test_owner/test_repo/put.json
+++ b/spec/fixtures/repositories/test_owner/test_repo/put.json
@@ -1,0 +1,71 @@
+{
+  "scm": "git",
+  "has_wiki": false,
+  "description": "",
+  "links": {
+    "watchers": {
+      "href": "https://api.bitbucket.org/2.0/repositories/evzijst/atlassian-connect-fork/watchers"
+    },
+    "commits": {
+      "href": "https://api.bitbucket.org/2.0/repositories/evzijst/atlassian-connect-fork/commits"
+    },
+    "self": {
+      "href": "https://api.bitbucket.org/2.0/repositories/evzijst/atlassian-connect-fork"
+    },
+    "html": {
+      "href": "https://bitbucket.org/evzijst/atlassian-connect-fork"
+    },
+    "avatar": {
+      "href": "https://bitbucket.org/m/3a846b46851a/img/language-avatars/default_16.png"
+    },
+    "forks": {
+      "href": "https://api.bitbucket.org/2.0/repositories/evzijst/atlassian-connect-fork/forks"
+    },
+    "clone": [
+      {
+        "href": "https://bitbucket.org/evzijst/atlassian-connect-fork.git",
+        "name": "https"
+      },
+      {
+        "href": "ssh://git@bitbucket.org/evzijst/atlassian-connect-fork.git",
+        "name": "ssh"
+      }
+    ],
+    "pullrequests": {
+      "href": "https://api.bitbucket.org/2.0/repositories/evzijst/atlassian-connect-fork/pullrequests"
+    }
+  },
+  "fork_policy": "allow_forks",
+  "language": "",
+  "created_on": "2013-08-26T18:13:07.339080+00:00",
+  "parent": {
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/evzijst/atlassian-connect"
+      },
+      "avatar": {
+        "href": "https://bitbucket-assetroot.s3.amazonaws.com/m/3a846b46851a/img/language-avatars/default_16.png"
+      }
+    },
+    "full_name": "evzijst/atlassian-connect",
+    "name": "atlassian-connect"
+  },
+  "full_name": "evzijst/atlassian-connect-fork",
+  "has_issues": false,
+  "owner": {
+    "username": "evzijst",
+    "display_name": "Erik van Zijst",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/users/evzijst"
+      },
+      "avatar": {
+        "href": "https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2013/Oct/28/evzijst-avatar-3454044670-3_avatar.png"
+      }
+    }
+  },
+  "updated_on": "2013-08-26T18:13:07.514065+00:00",
+  "size": 17657351,
+  "is_private": false,
+  "name": "New repository name"
+}

--- a/spec/lib/tinybucket/api/repo_api_spec.rb
+++ b/spec/lib/tinybucket/api/repo_api_spec.rb
@@ -18,32 +18,23 @@ RSpec.describe Tinybucket::Api::RepoApi do
 
   before { stub_apiresponse(:get, request_path) if request_path }
 
-  describe 'find' do
-    subject { api.find }
-
-    context 'when without repo_owner and repo_slug' do
-      let(:repo_owner) { nil }
-      let(:repo_slug) { nil }
-      it { expect { subject }.to raise_error(ArgumentError) }
-    end
-
-    context 'when without repo_owner' do
-      let(:repo_owner) { nil }
-      it { expect { subject }.to raise_error(ArgumentError) }
-    end
-
-    context 'when without repo_slug' do
-      let(:repo_slug) { nil }
-      it { expect { subject }.to raise_error(ArgumentError) }
-    end
-
-    context 'when with repo_owner and repo_slug' do
-      let(:request_path) { "/repositories/#{repo_owner}/#{repo_slug}" }
-      it { expect(subject).to be_an_instance_of(Tinybucket::Model::Repository) }
-    end
+  describe '#put' do 
+    let(:request_path) { "/repositories/#{repo_owner}/#{repo_slug}" }
+    let(:params){ {} }
+    before { stub_apiresponse(:put, request_path) } 
+    subject { api.put(params) }
+    it { expect(subject).to be_a(Tinybucket::Model::Repository) }
   end
 
-  describe 'watchers' do
+  describe '#delete' do
+    let(:request_path) { "/repositories/#{repo_owner}/#{repo_slug}" }
+    subject{ api.delete }
+    before { stub_apiresponse(:delete, request_path) } 
+    it { expect(subject).to be_nil }
+  end
+
+
+  describe '#watchers' do
     subject { api.watchers }
 
     context 'when without repo_owner and repo_slug' do
@@ -70,7 +61,7 @@ RSpec.describe Tinybucket::Api::RepoApi do
     end
   end
 
-  describe 'forks' do
+  describe '#forks' do
     subject { api.forks }
 
     context 'when without repo_owner and repo_slug' do

--- a/spec/lib/tinybucket/api/repos_api_spec.rb
+++ b/spec/lib/tinybucket/api/repos_api_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Tinybucket::Api::ReposApi do
 
   it { expect(api).to be_a_kind_of(Tinybucket::Api::BaseApi) }
 
-  describe 'list' do
+  describe '#list' do
     subject { api.list(options) }
 
     before { stub_apiresponse(:get, request_path) }
@@ -15,13 +15,44 @@ RSpec.describe Tinybucket::Api::ReposApi do
     context 'without owner' do
       let(:options) { {} }
       let(:request_path) { '/repositories' }
-      it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
+      it { expect(subject).to be_a(Tinybucket::Model::Page) }
+      let(:repositories){ subject.items }
+      it { expect(repositories).not_to be_empty }
+      it { expect(repositories).to all(be_a(Tinybucket::Model::Repository)) }
     end
 
     context 'with owner' do
-      let(:options) { { owner: 'test_owner' } }
-      let(:request_path) { '/repositories/test_owner' }
-      it { expect(subject).to be_an_instance_of(Tinybucket::Model::Page) }
+      let(:owner) { 'test_owner' }
+      let(:options) { { owner: owner } }
+      let(:request_path) { "/repositories/#{owner}" }
+      it { expect(subject).to be_a(Tinybucket::Model::Page) }
+      let(:repositories){ subject.items }
+      it { expect(repositories).not_to be_empty }
+      it { expect(repositories).to all(be_a(Tinybucket::Model::Repository)) }
+      let(:usernames){ repositories.map{|item| item.owner["username"]} }
+      it { expect(usernames.uniq.count).to eq(1) }
+      it { expect(usernames).to eq(['test_owner']) }
     end
+  end
+
+  describe '#find' do
+    let(:owner) { 'test_owner' }
+    let(:slug) { 'test_repo' }
+    let(:request_path) { "/repositories/#{owner}/#{slug}" }
+
+    before { stub_apiresponse(:get, request_path) }
+    subject{ api.find(owner, slug) }
+    it { expect(subject).to be_a(Tinybucket::Model::Repository) }
+  end
+
+  describe '#create' do
+    let(:params) { {} }
+    let(:owner) { 'test_owner' }
+    let(:slug) { 'test_repo' }
+    let(:request_path) { "/repositories/#{owner}/#{slug}" }
+    before { stub_apiresponse(:post, request_path) }
+
+    subject { api.create(owner, slug, params) }
+    it { expect(subject).to be_a(Tinybucket::Model::Repository) }
   end
 end

--- a/spec/lib/tinybucket/model/repository_spec.rb
+++ b/spec/lib/tinybucket/model/repository_spec.rb
@@ -17,7 +17,13 @@ RSpec.describe Tinybucket::Model::Repository do
     m = Tinybucket::Model::Repository.new(model_json)
     m.repo_owner = owner
     m.repo_slug  = slug
+    m
+  end
 
+  let(:empty_model) do
+    m = Tinybucket::Model::Repository.new({})
+    m.repo_owner = owner
+    m.repo_slug  = slug
     m
   end
 
@@ -28,22 +34,25 @@ RSpec.describe Tinybucket::Model::Repository do
                   load_json_fixture('repository')
 
   describe 'model can reloadable' do
-    let(:repo) do
-      m = Tinybucket::Model::Repository.new({})
-      m.repo_owner = owner
-      m.repo_slug  = slug
-      m
-    end
-    before { @model = repo }
+    before { @model = empty_model }
     it_behaves_like 'the model is reloadable'
   end
 
-  describe '#create' do
-    pending 'TODO implement method'
+  describe '#update' do
+    let(:request_path) { "/repositories/#{owner}/#{slug}" }
+    let(:new_name) { 'New repository name' }
+    before { stub_apiresponse(:put, request_path) }
+    it { expect(model.name).not_to eq(new_name) }
+    subject{ model.update(name: new_name ) }
+    it { expect(subject).to be_a(Tinybucket::Model::Repository) }
+    it { expect(subject.name).to eq(new_name) }
   end
 
   describe '#destroy' do
-    pending 'TODO implement method'
+    let(:request_path) { "/repositories/#{owner}/#{slug}" }
+    before { stub_apiresponse(:delete, request_path) }
+    subject{ model.destroy }
+    it { expect(subject).to be_nil }
   end
 
   describe '#pull_requests' do

--- a/spec/lib/tinybucket/resource/repos_spec.rb
+++ b/spec/lib/tinybucket/resource/repos_spec.rb
@@ -4,36 +4,58 @@ RSpec.describe Tinybucket::Resource::Repos do
   include ApiResponseMacros
 
   let(:options) { {} }
-  let(:resource) { Tinybucket::Resource::Repos.new(owner, options) }
 
   describe 'Public Repos Resource' do
     let(:owner) { nil }
-
-    describe '#create' do
+    let(:resource) { Tinybucket::Resource::Repos.new(owner, options) }
+    
+    describe '#list' do
       let(:params) { {} }
-      subject { resource.create(params) }
-      it { expect { subject }.to raise_error(NotImplementedError) }
+      let(:request_path) { '/repositories' }
+      before { stub_enum_response(:get, request_path) }
+      subject { resource.list(params) }
+      it { expect(subject).to be_a(Tinybucket::Model::Page) }
+      let(:repositories){ subject.items }
+      it { expect(repositories).not_to be_empty }
+      it { expect(repositories).to all(be_a(Tinybucket::Model::Repository)) }
     end
 
     describe '#find' do
-      let(:params) { {} }
-      subject { resource.find(params) }
-      it { expect { subject }.to raise_error(NotImplementedError) }
+      let(:slug) { 'test_repo' }
+      subject { resource.find(slug) }
+
+      it { expect(subject).to be_nil }
+    end
+
+    describe '#create' do
+      context 'with repo slug' do 
+        let(:params) { {} }
+        let(:slug) { 'test_repo' }
+        subject{ resource.create(slug, params) }
+        it { expect{ subject }.to raise_error(ArgumentError, 'must provide an owner in order to create a repository') }
+      end
+
+      context 'without repo slug' do 
+        let(:params) { {} }
+        let(:slug) { nil }
+        subject{ resource.create(slug, params) }
+        it { expect{ subject }.to raise_error(ArgumentError, 'must provide an owner in order to create a repository') }
+      end
     end
 
     describe 'Enumerable Methods' do
       let(:request_path) { '/repositories' }
       before { stub_enum_response(:get, request_path) }
-
+      
       describe '#take(1)' do
         subject { resource.take(1) }
-        it { expect(subject).to be_an_instance_of(Array) }
+        it { expect(subject).to be_an(Array) }
       end
 
       describe '#each' do
         it 'iterate models' do
           resource.each do |m|
-            expect(m).to be_an_instance_of(Tinybucket::Model::Repository)
+            expect(m).to be_a(Tinybucket::Model::Repository)
           end
         end
       end
@@ -42,17 +64,56 @@ RSpec.describe Tinybucket::Resource::Repos do
 
   describe 'Owner\'s Repos Resource' do
     let(:owner) { 'test_owner' }
+    let(:resource) { Tinybucket::Resource::Repos.new(owner, options) }
 
-    describe '#create' do
+    describe '#list' do
       let(:params) { {} }
-      subject { resource.create(params) }
-      it { expect { subject }.to raise_error(NotImplementedError) }
+      let(:request_path) { "/repositories/#{owner}" }
+      before { stub_enum_response(:get, request_path) }
+      subject { resource.list(params) }
+      it { expect(subject).to be_a(Tinybucket::Model::Page) }
+      let(:repositories){ subject.items }
+      it { expect(repositories).not_to be_empty }
+      it { expect(repositories).to all(be_a(Tinybucket::Model::Repository)) }
+      let(:usernames){ repositories.map{|item| item.owner["username"]} }
+      it { expect(usernames.uniq.count).to eq(1) }
+      it { expect(usernames).to eq(['test_owner']) }
     end
 
     describe '#find' do
-      let(:params) { {} }
-      subject { resource.find(params) }
-      it { expect { subject }.to raise_error(NotImplementedError) }
+      context 'with repo slug' do 
+        let(:slug) { 'test_repo' }
+        let(:request_path) { "/repositories/#{owner}/#{slug}" }
+        before { stub_enum_response(:get, request_path) }
+        subject { resource.find(slug) }
+        it { expect(subject).not_to be_nil }
+        it { expect(subject).to be_a(Tinybucket::Model::Repository)}
+      end
+
+      context 'without repo slug' do 
+        let(:slug) { nil } 
+        subject { resource.find(slug) }
+        it { expect(subject).to be_nil }
+      end
+    end
+
+    describe '#create' do
+      context 'with repo slug' do 
+        let(:params) { {} }
+        let(:slug) { 'test_repo' }
+        let(:request_path) { "/repositories/#{owner}/#{slug}" }
+        before { stub_enum_response(:post, request_path) }
+        subject{ resource.create(slug, params) }
+        it { expect(subject).not_to be_nil }
+        it { expect(subject).to be_a(Tinybucket::Model::Repository) }        
+      end
+
+      context 'without repo slug' do 
+        let(:params) { {} }
+        let(:slug) { nil }
+        subject{ resource.create(slug, params) }
+        it { expect{ subject }.to raise_error(ArgumentError, 'must provide a repo slug in order to create a repository') }
+      end
     end
 
     describe 'Enumerable Methods' do
@@ -61,13 +122,13 @@ RSpec.describe Tinybucket::Resource::Repos do
 
       describe '#take(1)' do
         subject { resource.take(1) }
-        it { expect(subject).to be_an_instance_of(Array) }
+        it { expect(subject).to be_an(Array) }
       end
 
       describe '#each' do
         it 'iterate models' do
           resource.each do |m|
-            expect(m).to be_an_instance_of(Tinybucket::Model::Repository)
+            expect(m).to be_a(Tinybucket::Model::Repository)
           end
         end
       end


### PR DESCRIPTION
All the pending repo-specific functionality has been developed. Now is possible to perform the following related actions:

Read the list of public repositories
Read the list of user-specific repositories
Find a specific repository
Create a new repository
Update an existing repository
Delete an existing repository
NOTE: The :put, :post, :patch request calls have been modified to include the parameters in JSON format so now is possible to pass numeric and boolean values. Before, they were transformed to string values raising a field error in those situations.